### PR TITLE
Allow to override coveralls endpoint.

### DIFF
--- a/lib/excoveralls/post.ex
+++ b/lib/excoveralls/post.ex
@@ -9,7 +9,7 @@ defmodule ExCoveralls.Post do
     if options[:verbose] do
       IO.puts JSX.prettify!(json)
     end
-    Poster.execute(json)
+    Poster.execute(json, options)
   end
 
   def generate_json(source_info, options) do

--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -8,9 +8,9 @@ defmodule ExCoveralls.Poster do
   Create a temporarily json file and post it to server using hackney library.
   Then, remove the file after it's completed.
   """
-  def execute(json) do
+  def execute(json, options \\ []) do
     File.write!(@file_name, json)
-    response = send_file(@file_name)
+    response = send_file(@file_name, options)
     File.rm!(@file_name)
 
     case response do
@@ -19,9 +19,10 @@ defmodule ExCoveralls.Poster do
     end
   end
 
-  defp send_file(file_name) do
+  defp send_file(file_name, options) do
     :hackney.start
-    response = :hackney.request(:post, "https://coveralls.io/api/v1/jobs", [],
+    endpoint = options[:endpoint] || "https://coveralls.io"
+    response = :hackney.request(:post, "#{endpoint}/api/v1/jobs", [],
       {:multipart, [
         {:file, file_name,
           {"form-data", [{"name", "json_file"}, {"filename", file_name}]},

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -104,6 +104,7 @@ defmodule Mix.Tasks.Coveralls do
       if Enum.count(params) <= 1 do
         Mix.Tasks.Coveralls.do_run(args,
           [ type:         "post",
+            endpoint:     Application.get_env(:excoveralls, :endpoint),
             token:        extract_token(params),
             service_name: extract_service_name(options),
             branch:       options[:branch] || "",
@@ -126,4 +127,3 @@ defmodule Mix.Tasks.Coveralls do
     end
   end
 end
-

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -69,9 +69,9 @@ defmodule Mix.Tasks.CoverallsTest do
     Mix.Tasks.Coveralls.Post.run(args)
     assert(called Mix.Task.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
-             [type: "post", token: "dummy_token", service_name: "dummy_service_name",
-              branch: "branch", committer: "committer", message: "message",
-              args: []])
+             [type: "post", endpoint: nil, token: "dummy_token",
+              service_name: "dummy_service_name", branch: "branch",
+              committer: "committer", message: "message", args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -11,7 +11,7 @@ defmodule ExCoveralls.PostTest do
                  coverage: @counts
                ]]
 
-  test_with_mock "execute", ExCoveralls.Poster, [execute: fn(_) -> "result" end] do
+  test_with_mock "execute", ExCoveralls.Poster, [execute: fn(_, _) -> "result" end] do
     original_token = System.get_env("COVERALLS_REPO_TOKEN")
     System.put_env("COVERALLS_REPO_TOKEN", "dummy_token")
 


### PR DESCRIPTION
Hi,
I am currently working on a small project with an API compatible with Coveralls,
and I would like to be able to customize the endpoint to be able to change https://coveralls.io
when posting the stats.
I made a small change to read `COVERALLS_ENDPOINT` for the `mix coveralls.post` task.
The behavior stays the same if the environment variable is not present.
Thanks.