### PR TITLE
added --sha parameter for non-Travis compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Usage: mix coveralls.post [options] [coveralls-token]
   -b (--branch)       Branch name ('BRANCH' column at coveralls page)
   -c (--committer)    Committer name ('COMMITTER' column at coveralls page)
   -m (--message)      Commit message ('COMMIT' column at coveralls page)
+  -s (--sha)          Commit SHA (required when not using Travis) 
 ```
 
 ### [mix coveralls.travis] Post coverage to travis

--- a/lib/excoveralls/post.ex
+++ b/lib/excoveralls/post.ex
@@ -24,7 +24,8 @@ defmodule ExCoveralls.Post do
   defp generate_git_info(options) do
     [head: [
        committer_name: options[:committer],
-       message: options[:message]
+       message: options[:message],
+       id: options[:sha]
       ],
       branch: options[:branch]
     ]

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -99,7 +99,7 @@ defmodule Mix.Tasks.Coveralls do
     @default_service_name "excoveralls"
 
     def run(args) do
-      {options, params, _} = OptionParser.parse(args, aliases: [n: :name, b: :branch, c: :committer, m: :message])
+      {options, params, _} = OptionParser.parse(args, aliases: [n: :name, b: :branch, c: :committer, m: :message, s: :sha])
 
       if Enum.count(params) <= 1 do
         Mix.Tasks.Coveralls.do_run(args,
@@ -109,6 +109,7 @@ defmodule Mix.Tasks.Coveralls do
             service_name: extract_service_name(options),
             branch:       options[:branch] || "",
             committer:    options[:committer] || "",
+            sha:          options[:sha] || "",
             message:      options[:message] || "[no commit message]" ])
       else
         raise %ExCoveralls.InvalidOptionError{message: "Parameter format is invalid"}

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,5 @@
   "idna": {:hex, :idna, "1.0.2"},
   "jsx": {:hex, :jsx, "2.4.0"},
   "meck": {:hex, :meck, "0.8.2"},
-  "mock": {:git, "git://github.com/parroty/mock.git", "33d095a9b028f9f97f6d506ae6b2feb34630fdc5", [ref: "fix"]},
+  "mock": {:git, "https://github.com/parroty/mock.git", "33d095a9b028f9f97f6d506ae6b2feb34630fdc5", [ref: "fix"]},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.4"}}

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -65,13 +65,13 @@ defmodule Mix.Tasks.CoverallsTest do
     System.put_env("COVERALLS_REPO_TOKEN", "dummy_token")
     System.put_env("COVERALLS_SERVICE_NAME", "dummy_service_name")
 
-    args = ["-b", "branch", "-c", "committer", "-m", "message"]
+    args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf"]
     Mix.Tasks.Coveralls.Post.run(args)
     assert(called Mix.Task.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
               service_name: "dummy_service_name", branch: "branch",
-              committer: "committer", message: "message", args: []])
+              committer: "committer", sha: "asdf", message: "message", args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -24,14 +24,14 @@ defmodule ExCoveralls.PostTest do
 
   test_with_mock "generate json", System, [cmd: fn(_, _) -> "" end] do
 
-    assert(Post.generate_json(@source_info, [token: "1234567890", service_name: "local", branch: "", committer: "", message: ""]) ==
+    assert(Post.generate_json(@source_info, [token: "1234567890", service_name: "local", branch: "", committer: "", message: "", sha: ""]) ==
        "{\"repo_token\":\"1234567890\"," <>
          "\"service_name\":\"local\"," <>
          "\"source_files\":" <>
            "[{\"name\":\"test/fixtures/test.ex\"," <>
              "\"source\":\"defmodule Test do\\n  def test do\\n  end\\nend\\n\"," <>
              "\"coverage\":[0,1,null,null]}]," <>
-         "\"git\":{\"head\":{\"committer_name\":\"\",\"message\":\"\"},\"branch\":\"\"}}"
+         "\"git\":{\"head\":{\"committer_name\":\"\",\"message\":\"\",\"id\":\"\"},\"branch\":\"\"}}"
     )
   end
 end


### PR DESCRIPTION
When debugging an [issue](https://github.com/lemurheavy/coveralls-public/issues/672#issuecomment-159724697) with @dokie I noticed that none of his builds were coming through from CircleCi with a commit SHA. When sending coverage data to Coveralls from Travis it's ok to omit that because we query their API to pull the commit info. But for other CI's it needs to be specified explicitly.

I've added SHA as the `-s` parameter here, but this could be refactored to pull git info directly from the environment. Here's how we do that in [coveralls-ruby](https://github.com/lemurheavy/coveralls-ruby/blob/master/lib/coveralls/configuration.rb#L138):

```ruby
hash[:head] = {
  :id => ENV.fetch("GIT_ID", `git log -1 --pretty=format:'%H'`),
  :author_name => ENV.fetch("GIT_AUTHOR_NAME", `git log -1 --pretty=format:'%aN'`),
  :author_email => ENV.fetch("GIT_AUTHOR_EMAIL", `git log -1 --pretty=format:'%ae'`),
  :committer_name => ENV.fetch("GIT_COMMITTER_NAME", `git log -1 --pretty=format:'%cN'`),
  :committer_email => ENV.fetch("GIT_COMMITTER_EMAIL", `git log -1 --pretty=format:'%ce'`),
  :message => ENV.fetch("GIT_MESSAGE", `git log -1 --pretty=format:'%s'`)
}

hash[:branch] = ENV.fetch("GIT_BRANCH", `git rev-parse --abbrev-ref HEAD`)
```

Perhaps someone with more Elixir-foo could make that happen eventually.

Thanks!