### PR TITLE
Add CircleCI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ end
 ## Mix Tasks
 - [mix coveralls](#mix-coveralls-show-coverage)
 - [mix coveralls.travis](#mix-coverallstravis-post-coverage-from-travis)
+- [mix coveralls.circle](#mix-coverallscircle-post-coverage-from-circle)
 - [mix coveralls.post](#mix-coverallspost-post-coverage-from-localhost)
 - [mix coveralls.detail](#mix-coverallsdetail-show-coverage-with-detail)
 
@@ -99,9 +100,9 @@ Usage: mix coveralls.post <Options>
     -s (--sha)          Commit SHA (required when not using Travis)
 ```
 
-### [mix coveralls.travis] Post coverage to travis
+### [mix coveralls.travis] Post coverage from travis
 Specify `mix coveralls.travis` in the `.travis.yml`.
-This task is for submiting the result to the coveralls server when Travis-CI build is executed.
+This task is for submitting the result to the coveralls server when Travis-CI build is executed.
 
 #### .travis.yml
 ```
@@ -119,6 +120,20 @@ script:
 If you're using [Travis Pro](https://travis-ci.com/) for a private
 project, Use `coveralls.travis --pro` and ensure your coveralls.io
 repo token is available via the `COVERALLS_REPO_TOKEN` environment
+variable.
+
+### [mix coveralls.circle] Post coverage from circle
+Specify `mix coveralls.circle` in the `circle.yml`.
+This task is for submitting the result to the coveralls server when Circle-CI build is executed.
+
+#### circle.yml
+```
+test:
+  override:    
+    - mix coveralls.circle
+```
+
+Ensure your coveralls.io repo token is available via the `COVERALLS_REPO_TOKEN` environment
 variable.
 
 ### [mix coveralls.post] Post coverage from any host

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -8,10 +8,12 @@ defmodule ExCoveralls do
   alias ExCoveralls.ConfServer
   alias ExCoveralls.StatServer
   alias ExCoveralls.Travis
+  alias ExCoveralls.Circle
   alias ExCoveralls.Local
   alias ExCoveralls.Post
 
   @type_travis  "travis"
+  @type_circle  "circle"
   @type_local   "local"
   @type_post    "post"
 
@@ -47,6 +49,13 @@ defmodule ExCoveralls do
   """
   def analyze(stats, @type_travis, options) do
     Travis.execute(stats, options)
+  end
+
+  @doc """
+  Logic for posting from circle-ci server
+  """
+  def analyze(stats, @type_circle, options) do
+    Circle.execute(stats, options)
   end
 
   @doc """

--- a/lib/excoveralls/circle.ex
+++ b/lib/excoveralls/circle.ex
@@ -1,0 +1,72 @@
+defmodule ExCoveralls.Circle do
+  @moduledoc """
+  Handles circle-ci integration with coveralls.
+  """
+  alias ExCoveralls.Poster
+
+  def execute(stats, options) do
+    json = generate_json(stats, Enum.into(options, %{}))
+    if options[:verbose] do
+      IO.puts JSX.prettify!(json)
+    end
+    Poster.execute(json)
+  end
+
+  def generate_json(stats, options \\ %{})
+  def generate_json(stats, options) do
+    JSX.encode!([
+      repo_token: get_repo_token,
+      service_name: "circle-ci",
+      service_number: get_build_num,
+      service_job_id: get_build_num,
+      service_pull_request: get_pull_request,
+      source_files: stats,
+      git: generate_git_info,
+      parallel: options[:parallel]
+    ])
+  end
+
+  defp generate_git_info do
+    [head: [
+       committer_name: get_committer,
+       message: get_message!,
+       id: get_sha
+      ],
+      branch: get_branch
+    ]
+  end
+
+  defp get_pull_request do
+    case Regex.run(~r/(\d+)$/, System.get_env("CI_PULL_REQUEST") || "") do
+      [_, id] -> id
+      _ -> nil
+    end
+  end
+
+  defp get_message! do
+    case System.cmd("git", ["log", "-1", "--pretty=format:%s"]) do
+      {message, _} -> message
+      _ -> "[no commit message]"
+    end
+  end
+
+  defp get_committer do
+    System.get_env("CIRCLE_USERNAME")
+  end
+
+  defp get_sha do
+    System.get_env("CIRCLE_SHA1")
+  end
+
+  defp get_branch do
+    System.get_env("CIRCLE_BRANCH")
+  end
+
+  defp get_build_num do
+    System.get_env("CIRCLE_BUILD_NUM")
+  end
+
+  defp get_repo_token do
+    System.get_env("COVERALLS_REPO_TOKEN")
+  end
+end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -88,6 +88,17 @@ defmodule Mix.Tasks.Coveralls do
     end
   end
 
+  defmodule Circle do
+    @moduledoc """
+    Provides an entry point for CircleCI's script.
+    """
+    use Mix.Task
+
+    def run(args) do
+      Mix.Tasks.Coveralls.do_run(args, [type: "circle"])
+    end
+  end
+
   defmodule Post do
     @moduledoc """
     Provides an entry point for posting test coverage to

--- a/test/circle_test.exs
+++ b/test/circle_test.exs
@@ -1,0 +1,74 @@
+defmodule ExCoveralls.CircleTest do
+  use ExUnit.Case
+  import Mock
+  alias ExCoveralls.Circle
+
+  @content     "defmodule Test do\n  def test do\n  end\nend\n"
+  @counts      [0, 1, nil, nil]
+  @source      "test/fixtures/test.ex"
+  @source_info [[name: "test/fixtures/test.ex",
+                 source: @content,
+                 coverage: @counts
+               ]]
+
+  setup do
+    # Capture existing values
+    orig_vars = ~w(CI_PULL_REQUEST CIRCLE_USERNAME CIRCLE_SHA1 CIRCLE_BRANCH CIRCLE_BUILD_NUM COVERALLS_REPO_TOKEN)
+    |> Enum.map(fn var -> {var, System.get_env(var)} end)
+
+    on_exit fn ->
+      # Reset env vars
+      for {k, v} <- orig_vars do
+        if v != nil do
+          System.put_env(k, v)
+        else
+          System.delete_env(k)
+        end
+      end
+    end
+
+    # No additional context
+    {:ok, []}
+  end
+
+  test_with_mock "execute", ExCoveralls.Poster, [execute: fn(_) -> "result" end] do
+    assert(Circle.execute(@source_info,[]) == "result")
+  end
+
+  test "generate json for circle" do
+    json = Circle.generate_json(@source_info)
+    assert(json =~ ~r/service_job_id/)
+    assert(json =~ ~r/service_name/)
+    assert(json =~ ~r/service_number/)
+    assert(json =~ ~r/source_files/)
+    assert(json =~ ~r/git/)
+  end
+
+  test "submits as `circle-ci` by default" do
+    parsed = Circle.generate_json(@source_info) |> JSX.decode!
+    assert(%{ "service_name" => "circle-ci" } = parsed)
+  end
+
+  test "generate from env vars" do
+    System.put_env("CI_PULL_REQUEST", "https://github.com/parroty/excoveralls/pull/39")
+    System.put_env("CIRCLE_USERNAME", "username")
+    System.put_env("CIRCLE_SHA1", "sha1")
+    System.put_env("CIRCLE_BRANCH", "branch")
+    System.put_env("CIRCLE_BUILD_NUM", "0")
+    System.put_env("COVERALLS_REPO_TOKEN", "token")
+
+    {:ok, payload} = JSX.decode(Circle.generate_json(@source_info))
+    %{"git" =>
+      %{"branch" => branch,
+        "head" => %{"committer_name" => committer_name,
+                  "id" => id}}} = payload
+
+    assert(payload["service_pull_request"] == "39")
+    assert(branch == "branch")
+    assert(id == "sha1")
+    assert(committer_name == "username")
+    assert(payload["service_number"] == "0")
+    assert(payload["repo_token"] == "token")
+  end
+
+end

--- a/test/excoveralls_test.exs
+++ b/test/excoveralls_test.exs
@@ -9,6 +9,11 @@ defmodule ExCoverallsTest do
     assert called ExCoveralls.Travis.execute(@stats,[])
   end
 
+  test_with_mock "analyze circle", ExCoveralls.Circle, [execute: fn(_,_) -> nil end] do
+    ExCoveralls.analyze(@stats, "circle", [])
+    assert called ExCoveralls.Circle.execute(@stats,[])
+  end
+
   test_with_mock "analyze local", ExCoveralls.Local, [execute: fn(_,_) -> nil end] do
     ExCoveralls.analyze(@stats, "local", [])
     assert called ExCoveralls.Local.execute(@stats,[])

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -64,6 +64,18 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get == [type: "travis", pro: true, args: []])
   end
 
+  test_with_mock "circle", Mix.Task, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.Circle.run([])
+    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(ExCoveralls.ConfServer.get == [type: "circle", args: []])
+  end
+
+  test_with_mock "circle --parallel", Mix.Task, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.Circle.run(["--parallel"])
+    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(ExCoveralls.ConfServer.get == [type: "circle", parallel: true, args: []])
+  end
+
   test_with_mock "post with env vars", Mix.Task, [run: fn(_, _) -> nil end] do
     org_token = System.get_env("COVERALLS_REPO_TOKEN") || ""
     org_name  = System.get_env("COVERALLS_SERVICE_NAME") || ""


### PR DESCRIPTION
Adds a CircleCI task for integration without having to use the more limited `post` task.
- added `service_number` to align CircleCI build numbers with coveralls build numbers
- added `service_pull_request` to provide github PR link id
- added `--parallel` flag to allow multi-container builds
- extracts message from git log