### PR TITLE
Improve instructions for Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,20 +101,23 @@ Usage: mix coveralls.post <Options>
 ```
 
 ### [mix coveralls.travis] Post coverage from travis
-Specify `mix coveralls.travis` in the `.travis.yml`.
-This task is for submitting the result to the coveralls server when Travis-CI build is executed.
+Specify `mix coveralls.travis` as the build script in the `.travis.yml` and explicitly set the `MIX_ENV` environment to `TEST`.
+This task submits the result to Coveralls when the build is executed on Travis CI.
 
 #### .travis.yml
-```
-language: erlang
+```yml
+language: elixir
+
+elixir:
+  - 1.2.0
+
 otp_release:
-  - R16B
-before_install:
-  - git clone https://github.com/elixir-lang/elixir
-  - cd elixir && make && cd ..
-before_script: "export PATH=`pwd`/elixir/bin:$PATH"
-script:
-  - "MIX_ENV=test mix do deps.get, compile, coveralls.travis"
+  - 18.0
+
+env:
+  - MIX_ENV=test
+
+script: mix coveralls.travis
 ```
 
 If you're using [Travis Pro](https://travis-ci.com/) for a private
@@ -127,9 +130,9 @@ Specify `mix coveralls.circle` in the `circle.yml`.
 This task is for submitting the result to the coveralls server when Circle-CI build is executed.
 
 #### circle.yml
-```
+```yml
 test:
-  override:    
+  override:
     - mix coveralls.circle
 ```
 


### PR DESCRIPTION
Hi,

thanks for providing this library first of all! I just integrated `excoveralls` in a project and noticed the instructions for setting up code coverage reporting on Travis CI are a little outdated.

Elixir is now available as it's own language (in Beta, but works flawlessly) on Travis, which we can make use of to simplify the configuration file.
I added a note to explicitly set `MIX_ENV=test` via Travis' config file to prevent users from experiencing the `** (Mix) The task "coveralls.travis" could not be found` error.
Executing `mix do deps.get, compile` manually isn't needed anymore, it's part of the default `before_script` build step, see https://docs.travis-ci.com/user/languages/elixir#Default-commands. 

To verify this is working, here's the new `.travis.yml` config in action:

Commit: https://github.com/nTraum/kappa_metrics/blob/d1d5c2bb652aed7760fe5be061cb82aa79bf1098/.travis.yml
Build: https://travis-ci.org/nTraum/kappa_metrics/builds/106839141