### PR TITLE
fix umbrella source paths in report

### DIFF
--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -40,7 +40,7 @@ defmodule ExCoveralls do
   defp store_stats(stats, options, compile_path) do
     {sub_app_name, _sub_app_path} =
       ExCoveralls.SubApps.find(options[:sub_apps], compile_path)
-    stats = Stats.append_sub_app_name(stats, sub_app_name)
+    stats = Stats.append_sub_app_name(stats, sub_app_name, options[:apps_path])
     Enum.each(stats, fn(stat) -> StatServer.add(stat) end)
   end
 

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -72,9 +72,9 @@ defmodule ExCoveralls.Stats do
   @doc """
   Append the name of the sub app to the source info stats.
   """
-  def append_sub_app_name(stats, sub_app_name) do
+  def append_sub_app_name(stats, sub_app_name, apps_path) do
     Enum.map(stats, fn([{:name, name}, {:source, source}, {:coverage, coverage}]) ->
-      [{:name, "#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
+      [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
     end)
   end
 

--- a/lib/excoveralls/sub_apps.ex
+++ b/lib/excoveralls/sub_apps.ex
@@ -10,8 +10,12 @@ defmodule ExCoveralls.SubApps do
   end
 
   def parse(deps) do
-    Enum.map(deps, fn(dep) ->
-      {dep.app, dep.opts[:build]}
+    deps
+    |> Enum.map(&({&1.app, &1.opts[:build]}))
+    |> Enum.sort(fn ({_app1, build_path1}, {_app2, build_path2}) ->
+      # sort the longest paths first to avoid matching a path that contains another
+      # example "./apps/myapp_server" would contain path "./apps/myapp"
+      String.length(build_path1) > String.length(build_path2)
     end)
   end
 end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Coveralls do
 
     if options[:umbrella] do
       sub_apps = ExCoveralls.SubApps.parse(Mix.Dep.Umbrella.loaded)
-      options = options ++ [sub_apps: sub_apps]
+      options = options ++ [sub_apps: sub_apps, apps_path: Mix.Project.config[:apps_path]]
     end
 
     ExCoveralls.ConfServer.start

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.CoverallsTest do
       Mix.Tasks.Coveralls.run(["--umbrella"])
       assert(called Mix.Task.run("test", ["--cover"]))
       assert(ExCoveralls.ConfServer.get ==
-        [type: "local", umbrella: true, sub_apps: [], args: []])
+        [type: "local", umbrella: true, sub_apps: [], apps_path: nil, args: []])
     end)
   end
 

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -46,8 +46,8 @@ defmodule ExCoveralls.StatsTest do
   end
 
   test_with_mock "append sub app name", Cover, [module_path: fn(_) -> @source end] do
-    stats = Stats.append_sub_app_name(@source_info, "subapp")
-    assert(List.first(stats)[:name] == "subapp/test/fixtures/test.ex")
+    stats = Stats.append_sub_app_name(@source_info, "subapp", "apps")
+    assert(List.first(stats)[:name] == "apps/subapp/test/fixtures/test.ex")
   end
 
   test "trim empty suffix and prefix" do

--- a/test/sub_apps_test.exs
+++ b/test/sub_apps_test.exs
@@ -20,8 +20,8 @@ defmodule ExCoveralls.SubAppsTest do
   ]
 
   @parsed_subapps [
-      subapp0: "/Users/dummy/excoveralls/_build/dev/lib/subapp0",
-      subapp1: "/Users/dummy/excoveralls/_build/dev/lib/subapp1"
+      subapp1: "/Users/dummy/excoveralls/_build/dev/lib/subapp1",
+      subapp0: "/Users/dummy/excoveralls/_build/dev/lib/subapp0"
   ]
 
   test "parse returns sub apps" do


### PR DESCRIPTION
Ordering sub app paths to force the longest one to be matched first.
Also grabbing the apps path from the mix config so it will be appended
when building the stats path.

Paths to the source files in subapps would not properly reflect their
location in the directory. If a subapp's name contained another it was
possible for it to not have it's files listed correctly.

Given a project structure similar to:

```
umbrella/
    apps/
        myapp
        myapp_web
```

Where `myapp_web` has a dependency on `myapp` causing it to appear
after `myapp` in the results of `Mix.Dep.Umbrella.loaded`. This causes
all file paths reported to begin with `myapp`. Additionally the
`apps/` directory would not be prepended to allow coveralls.io to find
the source file.

The report would show these files:

```
myapp/lib/mod.ex
myapp/lib/web_mod.ex
```

Instead of:

```
apps/myapp/lib/mod.ex
apps/myapp_web/lib/web_mod.ex
```