### PR TITLE
Add support for minimum coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Stop words defined in `coveralls.json` will be excluded from the coverage calcul
 - template_path
   - A custom path for html reports. This defaults to the htmlcov report in the excoveralls lib.
 - minimum_coverage
-  - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 when test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules.
+  - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 if test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules. Should be expressed as a number between 0 and 100 signifying the minimum percentage of lines covered.
 
 ```javascript
 {
@@ -245,7 +245,8 @@ Stop words defined in `coveralls.json` will be excluded from the coverage calcul
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
     "output_dir": "cover/",
-    "template_path": "custom/path/to/template/"
+    "template_path": "custom/path/to/template/",
+    "minimum_coverage": 90
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Stop words defined in `coveralls.json` will be excluded from the coverage calcul
   - The directory which the HTML report will output to. Defaulted to `cover/`.
 - template_path
   - A custom path for html reports. This defaults to the htmlcov report in the excoveralls lib.
+- minimum_coverage
+  - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 when test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules.
 
 ```javascript
 {

--- a/coveralls.json
+++ b/coveralls.json
@@ -6,6 +6,7 @@
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": false,
     "output_dir": "cover/",
-    "template_path": "lib/templates/html/htmlcov/"    
+    "template_path": "lib/templates/html/htmlcov/",
+    "minimum_coverage": 0
   }
 }

--- a/lib/conf/coveralls.json
+++ b/lib/conf/coveralls.json
@@ -15,6 +15,7 @@
 
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": false,
-    "output_dir": "cover/"    
+    "output_dir": "cover/",
+    "minimum_coverage": 0
   }
 }

--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -15,6 +15,8 @@ defmodule ExCoveralls.Html do
     ExCoveralls.Local.print_summary(stats)
 
     Stats.source(stats, options[:filter]) |> generate_report
+
+    Stats.ensure_minimum_coverage(stats)
   end
 
   defp generate_report(map) do

--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -2,26 +2,11 @@ defmodule ExCoveralls.Html do
   @moduledoc """
   Generate HTML report of result.
   """
-  
+
   alias ExCoveralls.Html.View
+  alias ExCoveralls.Stats
 
   @file_name "excoveralls.html"
-
-  defmodule Line do
-    @moduledoc """
-    Stores count information and source for a sigle line.
-    """
-
-    defstruct coverage: nil, source: ""
-  end
-
-  defmodule Source do
-    @moduledoc """
-    Stores count information for a file and all source lines.
-    """
-
-    defstruct filename: "", coverage: 0, sloc: 0, hits: 0, misses: 0, source: []
-  end
 
   @doc """
   Provides an entry point for the module.
@@ -29,21 +14,7 @@ defmodule ExCoveralls.Html do
   def execute(stats, options \\ []) do
     ExCoveralls.Local.print_summary(stats)
 
-    source(stats, options[:filter]) |> generate_report
-  end
-
-  @doc """
-  Format the source code as an HTML report.
-  """
-  def source(stats, _patterns = nil), do: source(stats)
-  def source(stats, _patterns = []),  do: source(stats)
-  def source(stats, patterns) do
-    Enum.filter(stats, fn(stat) -> String.contains?(stat[:name], patterns) end) |> source
-  end
-
-  def source(stats) do
-    stats = Enum.sort(stats, fn(x, y) -> x[:name] <= y[:name] end)
-    stats |> transform_cov
+    Stats.source(stats, options[:filter]) |> generate_report
   end
 
   defp generate_report(map) do
@@ -65,70 +36,6 @@ defmodule ExCoveralls.Html do
       File.mkdir!(file_path)
     end
     File.write!(Path.expand(@file_name, file_path), content)
-  end
-
-  defp transform_cov(stats) do
-    files = Enum.map(stats, &populate_file/1)
-    {relevant, hits, misses} = Enum.reduce(files, {0,0,0}, &reduce_file_counts/2)
-    covered = relevant - misses
-
-    %{coverage: get_coverage(relevant, covered),
-      sloc: relevant,
-      hits: hits,
-      misses: misses,
-      files: files}
-  end
-
-  defp reduce_file_counts(%{sloc: sloc, hits: hits, misses: misses}, {s,h,m}) do
-    {s+sloc, h+hits, m+misses}
-  end
-
-  defp populate_file(stat) do
-    coverage = stat[:coverage]
-    source = map_source(stat[:source], coverage)
-    relevant = Enum.count(coverage, fn e -> e != nil end)
-    hits = Enum.reduce(coverage, 0, fn e, acc -> (e || 0) + acc end)
-    misses = Enum.count(coverage, fn e -> e == 0 end)
-    covered = relevant - misses
-
-    %Source{filename: stat[:name],
-      coverage: get_coverage(relevant, covered),
-      sloc: relevant,
-      hits: hits,
-      misses: misses,
-      source: source}
-  end
-
-  defp map_source(source, coverage) do
-    source
-    |> String.split("\n")
-    |> Enum.with_index()
-    |> Enum.map(&(populate_source(&1,coverage)))
-  end
-
-  defp populate_source({line, i}, coverage) do
-    %Line{coverage: Enum.at(coverage, i) , source: line}
-  end
-
-  defp get_coverage(relevant, covered) do
-    value = case relevant do
-      0 -> default_coverage_value
-      _ -> (covered / relevant) * 100
-    end
-
-    if value == trunc(value) do
-      trunc(value)
-    else
-      Float.round(value, 1)
-    end
-  end
-
-  defp default_coverage_value do
-    options = ExCoveralls.Settings.get_coverage_options
-    case Dict.fetch(options, "treat_no_relevant_lines_as_covered") do
-      {:ok, true} -> 100.0
-      _           -> 0.0
-    end
   end
 
 end

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -22,20 +22,16 @@ defmodule ExCoveralls.Local do
       source(stats, options[:filter]) |> IO.puts
     end
 
-    ensure_minimum_coverage(stats)
-  end
-
-  defp ensure_minimum_coverage(stats) do
     coverage_options = ExCoveralls.Settings.get_coverage_options
     minimum_coverage = coverage_options["minimum_coverage"] || 0
-    if minimum_coverage > 0 do
-      info = Enum.map(stats, fn(stat) -> [stat, calculate_count(stat[:coverage])] end)
-      totals   = Enum.reduce(info, %Count{}, fn([_, count], acc) -> append(count, acc) end)
-      actual_coverage = get_coverage(totals)
-      if actual_coverage < minimum_coverage do
-        IO.puts "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{actual_coverage}%."
-        exit({:shutdown, 1})
-      end
+    if minimum_coverage > 0, do: ensure_minimum_coverage(stats, minimum_coverage)
+  end
+
+  defp ensure_minimum_coverage(stats, minimum_coverage) do
+    result = ExCoveralls.Stats.source(stats)
+    if result.coverage < minimum_coverage do
+      IO.puts "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{result.coverage}%."
+      exit({:shutdown, 1})
     end
   end
 

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -22,17 +22,7 @@ defmodule ExCoveralls.Local do
       source(stats, options[:filter]) |> IO.puts
     end
 
-    coverage_options = ExCoveralls.Settings.get_coverage_options
-    minimum_coverage = coverage_options["minimum_coverage"] || 0
-    if minimum_coverage > 0, do: ensure_minimum_coverage(stats, minimum_coverage)
-  end
-
-  defp ensure_minimum_coverage(stats, minimum_coverage) do
-    result = ExCoveralls.Stats.source(stats)
-    if result.coverage < minimum_coverage do
-      IO.puts "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{result.coverage}%."
-      exit({:shutdown, 1})
-    end
+    ExCoveralls.Stats.ensure_minimum_coverage(stats)
   end
 
   @doc """

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -1,5 +1,4 @@
 defmodule ExCoveralls.Local do
-  require IEx
   @moduledoc """
   Locally displays the result to screen.
   """

--- a/lib/excoveralls/settings.ex
+++ b/lib/excoveralls/settings.ex
@@ -25,6 +25,17 @@ defmodule ExCoveralls.Settings do
     read_config("coverage_options") |> Enum.into(HashDict.new)
   end
 
+  @doc """
+  Get default coverage value for lines marked as not relevant.
+  """
+  def default_coverage_value do
+    case Dict.fetch(get_coverage_options, "treat_no_relevant_lines_as_covered") do
+      {:ok, true} -> 100.0
+      _           -> 0.0
+    end
+  end
+
+
   defp read_config_file(file_name) do
     if File.exists?(file_name) do
       case File.read!(file_name) |> JSX.decode do

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -201,4 +201,21 @@ defmodule ExCoveralls.Stats do
     %Line{coverage: Enum.at(coverage, i) , source: line}
   end
 
+  @doc """
+  Exit the process with a status of 1 if coverage is below the minimum.
+  """
+  def ensure_minimum_coverage(stats) do
+    coverage_options = ExCoveralls.Settings.get_coverage_options
+    minimum_coverage = coverage_options["minimum_coverage"] || 0
+    if minimum_coverage > 0, do: check_coverage_threshold(stats, minimum_coverage)
+  end
+
+  defp check_coverage_threshold(stats, minimum_coverage) do
+    result = source(stats)
+    if result.coverage < minimum_coverage do
+      IO.puts "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{result.coverage}%."
+      exit({:shutdown, 1})
+    end
+  end
+
 end

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -214,7 +214,8 @@ defmodule ExCoveralls.Stats do
   defp check_coverage_threshold(stats, minimum_coverage) do
     result = source(stats)
     if result.coverage < minimum_coverage do
-      IO.puts "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{result.coverage}%."
+      message = "FAILED: Expected minimum coverage of #{minimum_coverage}%, got #{result.coverage}%."
+      IO.puts IO.ANSI.format([:red, :bright, message])
       exit({:shutdown, 1})
     end
   end

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -2,7 +2,23 @@ defmodule ExCoveralls.Stats do
   @moduledoc """
   Provide calculation logics of coverage stats.
   """
-  alias ExCoveralls.Cover
+  alias ExCoveralls.{Cover, Settings}
+
+  defmodule Source do
+    @moduledoc """
+    Stores count information for a file and all source lines.
+    """
+
+    defstruct filename: "", coverage: 0, sloc: 0, hits: 0, misses: 0, source: []
+  end
+
+  defmodule Line do
+    @moduledoc """
+    Stores count information and source for a sigle line.
+    """
+
+    defstruct coverage: nil, source: ""
+  end
 
   @doc """
   Report the statistical information for he specified module.
@@ -109,9 +125,80 @@ defmodule ExCoveralls.Stats do
   end
 
   def skip_files(converage) do
-    skip = ExCoveralls.Settings.get_skip_files
+    skip = Settings.get_skip_files
     Enum.reject(converage, fn cov ->
       Enum.any?(skip, &Regex.match?(&1, cov[:name]))
     end)
   end
+
+  @doc """
+  Summarizes source coverage details.
+  """
+  def source(stats, _patterns = nil), do: source(stats)
+  def source(stats, _patterns = []),  do: source(stats)
+  def source(stats, patterns) do
+    Enum.filter(stats, fn(stat) -> String.contains?(stat[:name], patterns) end) |> source
+  end
+
+  def source(stats) do
+    stats = Enum.sort(stats, fn(x, y) -> x[:name] <= y[:name] end)
+    stats |> transform_cov
+  end
+
+  defp transform_cov(stats) do
+    files = Enum.map(stats, &populate_file/1)
+    {relevant, hits, misses} = Enum.reduce(files, {0,0,0}, &reduce_file_counts/2)
+    covered = relevant - misses
+
+    %{coverage: get_coverage(relevant, covered),
+      sloc: relevant,
+      hits: hits,
+      misses: misses,
+      files: files}
+  end
+
+  defp populate_file(stat) do
+    coverage = stat[:coverage]
+    source = map_source(stat[:source], coverage)
+    relevant = Enum.count(coverage, fn e -> e != nil end)
+    hits = Enum.reduce(coverage, 0, fn e, acc -> (e || 0) + acc end)
+    misses = Enum.count(coverage, fn e -> e == 0 end)
+    covered = relevant - misses
+
+    %Source{filename: stat[:name],
+      coverage: get_coverage(relevant, covered),
+      sloc: relevant,
+      hits: hits,
+      misses: misses,
+      source: source}
+  end
+
+  defp reduce_file_counts(%{sloc: sloc, hits: hits, misses: misses}, {s,h,m}) do
+    {s+sloc, h+hits, m+misses}
+  end
+
+  defp get_coverage(relevant, covered) do
+    value = case relevant do
+      0 -> Settings.default_coverage_value
+      _ -> (covered / relevant) * 100
+    end
+
+    if value == trunc(value) do
+      trunc(value)
+    else
+      Float.round(value, 1)
+    end
+  end
+
+  defp map_source(source, coverage) do
+    source
+    |> String.split("\n")
+    |> Enum.with_index()
+    |> Enum.map(&(populate_source(&1,coverage)))
+  end
+
+  defp populate_source({line, i}, coverage) do
+    %Line{coverage: Enum.at(coverage, i) , source: line}
+  end
+
 end

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -2,7 +2,8 @@ defmodule ExCoveralls.Stats do
   @moduledoc """
   Provide calculation logics of coverage stats.
   """
-  alias ExCoveralls.{Cover, Settings}
+  alias ExCoveralls.Cover
+  alias ExCoveralls.Settings
 
   defmodule Source do
     @moduledoc """

--- a/test/fixtures/no_relevant_lines_are_covered.json
+++ b/test/fixtures/no_relevant_lines_are_covered.json
@@ -1,0 +1,5 @@
+{
+  "coverage_options": {
+    "treat_no_relevant_lines_as_covered": true
+  }
+}

--- a/test/fixtures/no_relevant_lines_not_covered.json
+++ b/test/fixtures/no_relevant_lines_not_covered.json
@@ -1,0 +1,5 @@
+{
+  "coverage_options": {
+    "treat_no_relevant_lines_as_covered": false
+  }
+}

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -101,4 +101,28 @@ defmodule ExCoveralls.HtmlTest do
     %{size: size} = File.stat! report
     assert(size == @file_size)
   end
+
+  test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
+    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(100) end] do
+    output = capture_io(fn ->
+      assert catch_exit(Html.execute(@source_info)) == {:shutdown, 1}
+    end)
+    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50%.\n")
+  end
+
+  test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
+    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(49.9) end] do
+    assert capture_io(fn ->
+      Html.execute(@source_info)
+    end) =~ @stats_result
+  end
+
+  defp coverage_options(minimum_coverage) do
+    %{
+      "minimum_coverage" => minimum_coverage,
+      "output_dir" => @test_output_dir,
+      "template_path" => @test_template_path
+    }
+  end
+
 end

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -39,18 +39,18 @@ defmodule ExCoveralls.HtmlTest do
   @empty_result %{
     coverage: 0,
     files: [
-      %ExCoveralls.Html.Source{
+      %ExCoveralls.Stats.Source{
         coverage: 0,
         filename: "test/fixtures/test.ex",
         hits: 0,
         misses: 0,
         sloc: 0,
         source: [
-          %ExCoveralls.Html.Line{coverage: nil, source: "defmodule Test do"},
-          %ExCoveralls.Html.Line{coverage: nil, source: "  def test do"},
-          %ExCoveralls.Html.Line{coverage: nil, source: "  end"},
-          %ExCoveralls.Html.Line{coverage: nil, source: "end"},
-          %ExCoveralls.Html.Line{coverage: nil, source: ""}]}],
+          %ExCoveralls.Stats.Line{coverage: nil, source: "defmodule Test do"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: "  def test do"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: "  end"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: "end"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: ""}]}],
     hits: 0,
     misses: 0,
     sloc: 0}
@@ -58,37 +58,21 @@ defmodule ExCoveralls.HtmlTest do
   @source_result %{
     coverage: 50,
     files: [
-      %ExCoveralls.Html.Source{
+      %ExCoveralls.Stats.Source{
         coverage: 50,
         filename: "test/fixtures/test.ex",
         hits: 1,
         misses: 1,
         sloc: 2,
         source: [
-          %ExCoveralls.Html.Line{coverage: 0, source: "defmodule Test do"},
-          %ExCoveralls.Html.Line{coverage: 1, source: "  def test do"},
-          %ExCoveralls.Html.Line{coverage: nil, source: "  end"},
-          %ExCoveralls.Html.Line{coverage: nil, source: "end"},
-          %ExCoveralls.Html.Line{coverage: nil, source: ""}]}],
+          %ExCoveralls.Stats.Line{coverage: 0, source: "defmodule Test do"},
+          %ExCoveralls.Stats.Line{coverage: 1, source: "  def test do"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: "  end"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: "end"},
+          %ExCoveralls.Stats.Line{coverage: nil, source: ""}]}],
     hits: 1,
     misses: 1,
     sloc: 2}
-
-  test "display source information" do
-    assert(Html.source(@source_info) == @source_result)
-  end
-
-  test "display source information with nil filter" do
-    assert(Html.source(@source_info, nil) == @source_result)
-  end
-
-  test "display source information with empty filter" do
-    assert(Html.source(@source_info, []) == @source_result)
-  end
-
-  test "display source information with pattern filter" do
-    assert(Html.source(@source_info, ["test.ex"]) == @source_result)
-  end
 
   setup do
     path = Path.expand(@file_name, @test_output_dir)
@@ -116,23 +100,5 @@ defmodule ExCoveralls.HtmlTest do
     assert(File.read!(report) =~ "id='test/fixtures/test.ex'")
     %{size: size} = File.stat! report
     assert(size == @file_size)
-  end
-
-  test "display stats information fails with invalid data" do
-    assert_raise ArithmeticError, fn ->
-      Html.source(@invalid_source_info)
-    end
-  end
-
-  test "Empty (no relevant lines) file is calculated as 0.0%" do
-    results = Html.source(@empty_source_info)
-    assert(results.coverage == 0)
-  end
-
-  test_with_mock "Empty (no relevant lines) file with treat_no_relevant_lines_as_covered option is calculated as 100.0%",
-    ExCoveralls.Settings, [get_coverage_options: fn -> %{"treat_no_relevant_lines_as_covered" => true} end] do
-
-    results = Html.source(@empty_source_info)
-    assert(results.coverage == 100)
   end
 end

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -107,7 +107,7 @@ defmodule ExCoveralls.HtmlTest do
     output = capture_io(fn ->
       assert catch_exit(Html.execute(@source_info)) == {:shutdown, 1}
     end)
-    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50%.\n")
+    assert String.ends_with?(output, "\e[31m\e[1mFAILED: Expected minimum coverage of 100%, got 50%.\e[0m\n")
   end
 
   test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -84,7 +84,7 @@ defmodule ExCoveralls.LocalTest do
     output = capture_io(fn ->
       assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
     end)
-    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50.0%.\n")
+    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50%.\n")
   end
 
   test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -84,7 +84,7 @@ defmodule ExCoveralls.LocalTest do
     output = capture_io(fn ->
       assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
     end)
-    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50%.\n")
+    assert String.ends_with?(output, "\e[31m\e[1mFAILED: Expected minimum coverage of 100%, got 50%.\e[0m\n")
   end
 
   test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -87,4 +87,10 @@ defmodule ExCoveralls.LocalTest do
     assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50.0%.\n")
   end
 
+  test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
+    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end] do
+    assert capture_io(fn ->
+      Local.execute(@source_info)
+    end) =~ @stats_result
+  end
 end

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -78,4 +78,13 @@ defmodule ExCoveralls.LocalTest do
 
     assert String.ends_with?(Local.coverage(@empty_source_info), "[TOTAL] 100.0%")
   end
+
+  test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
+    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 100} end] do
+    output = capture_io(fn ->
+      assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
+    end)
+    assert String.ends_with?(output, "FAILED: Expected minimum coverage of 100%, got 50.0%.\n")
+  end
+
 end

--- a/test/settings_test.exs
+++ b/test/settings_test.exs
@@ -6,6 +6,8 @@ defmodule Excoveralls.SettingsTest do
   @fixture_default Path.dirname(__ENV__.file) <> "/fixtures/default.json"
   @fixture_custom  Path.dirname(__ENV__.file) <> "/fixtures/custom.json"
   @fixture_invalid Path.dirname(__ENV__.file) <> "/fixtures/invalid.json"
+  @fixture_not_covered Path.dirname(__ENV__.file) <> "/fixtures/no_relevant_lines_not_covered.json"
+  @fixture_covered Path.dirname(__ENV__.file) <> "/fixtures/no_relevant_lines_are_covered.json"
 
   test "returns default file path" do
     assert(Settings.Files.default_file
@@ -60,4 +62,21 @@ defmodule Excoveralls.SettingsTest do
       Settings.read_config("default_stop_words")
     end
   end
+
+  test_with_mock "default coverage value returns 100 when treating irrelevant lines as covered",
+    Settings.Files, [
+      default_file: fn -> @fixture_default end,
+      custom_file:  fn -> @fixture_covered end
+    ] do
+    assert Settings.default_coverage_value == 100
+  end
+
+  test_with_mock "default coverage value returns 0 when treating irrelevant lines as not covered",
+    Settings.Files, [
+      default_file: fn -> @fixture_default end,
+      custom_file:  fn -> @fixture_not_covered end
+    ] do
+    assert Settings.default_coverage_value == 0
+  end
+
 end


### PR DESCRIPTION
This pull request adds support for a new option in the `coveralls.json` file inside the `coverage_options` key: `minimum_coverage` (defaults to zero). When the user adds a value in this option, running `mix coveralls` or `mix coveralls.html` will exit with a status code of 1 if total coverage falls below that threshold. This is useful for stopping CI pipelines with tight coverage requirements.

I noticed the `Html` module had some totalization of stats in it, so those were moved into `Stats`. That has significantly cleaned up `Html`. There are many calculations for individual files still going on in the `Local` module, but I chose not to refactor those for now. We could tackle that on a later PR.

Let me know what you think! Cheers.