### PR TITLE
Make sure additional args can be passed to mix

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -52,8 +52,10 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   defp parse_common_options(args, options) do
-    {common_options, args, _} = OptionParser.parse(args, aliases: [u: :umbrella, v: :verbose])
-    {args, options ++ common_options}
+    {common_options, _remaining, unknown_args} = OptionParser.parse(args,
+      strict: [umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean],
+      aliases: [u: :umbrella, v: :verbose])
+    {unknown_args |> Enum.map(fn({k, _}) -> k end), options ++ common_options}
   end
 
   defp analyze_sub_apps(options) do

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -46,6 +46,16 @@ defmodule Mix.Tasks.CoverallsTest do
     end)
   end
 
+  test_with_mock "--no-start propagates to mix task", Mix.Task, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.run(["--no-start"])
+    assert(called Mix.Task.run("test", ["--cover", "--no-start"]))
+  end
+
+  test_with_mock "--unknown_arg withvalue", Mix.Task, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.run(["--unknown_arg withvalue", "--second"])
+    assert(called Mix.Task.run("test", ["--cover", "--unknown_arg withvalue", "--second"]))
+  end
+
   test_with_mock "detail", Mix.Task, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Detail.run([])
     assert(called Mix.Task.run("test", ["--cover"]))


### PR DESCRIPTION
For example --no-start

I was unable to pass `--no-start` down to the mix test task. This PR attempt to fix that. Feedback is much appreciated.