### PR TITLE
Fix tests error with elixir 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.1.0
   - 1.2.0
+  - 1.3.2
 otp_release:
-  - 18.0
+  - 18.2
 script:
   - "MIX_ENV=test mix do deps.get, compile, coveralls.travis"

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -7,6 +7,12 @@ defmodule Mix.Tasks.Coveralls do
 
   @shortdoc "Display the test coverage"
 
+  defmodule Runner do
+    def run(task, args) do
+      Mix.Task.run(task, args)
+    end
+  end
+
   def run(args) do
     {options, _, _} = OptionParser.parse(args, aliases: [h: :help])
 
@@ -44,7 +50,7 @@ defmodule Mix.Tasks.Coveralls do
     ExCoveralls.ConfServer.set(options ++ [args: args])
     ExCoveralls.StatServer.start
 
-    Mix.Task.run(test_task, ["--cover"] ++ args)
+    Runner.run(test_task, ["--cover"] ++ args)
 
     if options[:umbrella] do
       analyze_sub_apps(options)

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"exjsx": {:hex, :exjsx, "3.1.0", "d419162cb2d5be80070835c2c2b8c78c8c45907706c991d23f3750dae506d1e9", [:mix], [{:jsx, "~> 2.4.0", [hex: :jsx, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.1.0", "e999ef5fbd9d199b00953b26cbcb4396402e8e4fca6d2c48501253d98bd63723", [:make, :rebar], [{:ssl_verify_hostname, "~> 1.0", [hex: :ssl_verify_hostname, optional: false]}, {:idna, "~> 1.0", [hex: :idna, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.1.0", "e999ef5fbd9d199b00953b26cbcb4396402e8e4fca6d2c48501253d98bd63723", [:make, :rebar], [{:idna, "~> 1.0", [hex: :idna, optional: false]}, {:ssl_verify_hostname, "~> 1.0", [hex: :ssl_verify_hostname, optional: false]}]},
   "idna": {:hex, :idna, "1.0.2", "397e3d001c002319da75759b0a81156bf11849c71d565162436d50020cb7265e", [:make], []},
   "jsx": {:hex, :jsx, "2.4.0", "fb83830ac15e981b6ce310b645324ceecd01b1e0847d23921c33df829de5d2db", [:mix], []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.CoverallsTest do
   use ExUnit.Case, async: false
   import Mock
   import ExUnit.CaptureIO
+  alias Mix.Tasks.Coveralls.Runner
 
   # backup and restore the original config
   setup_all do
@@ -25,9 +26,9 @@ defmodule Mix.Tasks.CoverallsTest do
     :ok
   end
 
-  test_with_mock "local", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "local", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "local", args: []])
   end
 
@@ -37,68 +38,68 @@ defmodule Mix.Tasks.CoverallsTest do
     end) != ""
   end
 
-  test_with_mock "local with umbrella option", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "local with umbrella option", Runner, [run: fn(_, _) -> nil end] do
     capture_io(fn ->
       Mix.Tasks.Coveralls.run(["--umbrella"])
-      assert(called Mix.Task.run("test", ["--cover"]))
+      assert(called Runner.run("test", ["--cover"]))
       assert(ExCoveralls.ConfServer.get ==
         [type: "local", umbrella: true, sub_apps: [], apps_path: nil, args: []])
     end)
   end
 
-  test_with_mock "--no-start propagates to mix task", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "--no-start propagates to mix task", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.run(["--no-start"])
-    assert(called Mix.Task.run("test", ["--cover", "--no-start"]))
+    assert(called Runner.run("test", ["--cover", "--no-start"]))
   end
 
-  test_with_mock "--unknown_arg withvalue", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "--unknown_arg withvalue", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.run(["--unknown_arg withvalue", "--second"])
-    assert(called Mix.Task.run("test", ["--cover", "--unknown_arg withvalue", "--second"]))
+    assert(called Runner.run("test", ["--cover", "--unknown_arg withvalue", "--second"]))
   end
 
-  test_with_mock "detail", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "detail", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Detail.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "local", detail: true, filter: [], args: []])
   end
 
-  test_with_mock "html", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "html", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Html.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "html", filter: [], args: []])
   end
 
-  test_with_mock "travis", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "travis", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Travis.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "travis", args: []])
   end
 
-  test_with_mock "travis --pro", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "travis --pro", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Travis.run(["--pro"])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "travis", pro: true, args: []])
   end
 
-  test_with_mock "circle", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "circle", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Circle.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "circle", args: []])
   end
 
-  test_with_mock "circle --parallel", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "circle --parallel", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Circle.run(["--parallel"])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "circle", parallel: true, args: []])
   end
 
-  test_with_mock "semaphore", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "semaphore", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Semaphore.run([])
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get == [type: "semaphore", args: []])
   end
 
-  test_with_mock "post with env vars", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "post with env vars", Runner, [run: fn(_, _) -> nil end] do
     org_token = System.get_env("COVERALLS_REPO_TOKEN") || ""
     org_name  = System.get_env("COVERALLS_SERVICE_NAME") || ""
 
@@ -107,7 +108,7 @@ defmodule Mix.Tasks.CoverallsTest do
 
     args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf"]
     Mix.Tasks.Coveralls.Post.run(args)
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
               service_name: "dummy_service_name", branch: "branch",
@@ -117,7 +118,7 @@ defmodule Mix.Tasks.CoverallsTest do
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
   end
 
-  test_with_mock "post without env vars", Mix.Task, [run: fn(_, _) -> nil end] do
+  test_with_mock "post without env vars", Runner, [run: fn(_, _) -> nil end] do
     org_token = System.get_env("COVERALLS_REPO_TOKEN")
     org_name  = System.get_env("COVERALLS_SERVICE_NAME")
 
@@ -126,7 +127,7 @@ defmodule Mix.Tasks.CoverallsTest do
 
     args = ["-t", "token"]
     Mix.Tasks.Coveralls.Post.run(args)
-    assert(called Mix.Task.run("test", ["--cover"]))
+    assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "token",
               service_name: "excoveralls", branch: "",


### PR DESCRIPTION
Fixes tests error with following message, which was caused by directly mocking Mix.Task.run.
```
% mix test test/mix/tasks_test.exs
** (EXIT from #PID<0.70.0>) killed
```