### PR TITLE
Favor MapSet over Dict (elixir 1.2 deprecations)

### DIFF
--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -14,7 +14,7 @@ defmodule ExCoveralls.Html do
   def execute(stats, options \\ []) do
     ExCoveralls.Local.print_summary(stats)
 
-    Stats.source(stats, options[:filter]) |> generate_report
+    Stats.source(stats, options[:filter]) |> generate_report()
 
     Stats.ensure_minimum_coverage(stats)
   end
@@ -25,8 +25,8 @@ defmodule ExCoveralls.Html do
   end
 
   defp output_dir do
-    options = ExCoveralls.Settings.get_coverage_options
-    case Dict.fetch(options, "output_dir") do
+    options = ExCoveralls.Settings.get_coverage_options()
+    case Map.fetch(options, "output_dir") do
       {:ok, val} -> val
       _ -> "cover/"
     end

--- a/lib/excoveralls/html/view.ex
+++ b/lib/excoveralls/html/view.ex
@@ -14,7 +14,7 @@ defmodule ExCoveralls.Html.View do
 
     defp get_template_path() do
       options = ExCoveralls.Settings.get_coverage_options
-      case Dict.fetch(options, "template_path") do
+      case Map.fetch(options, "template_path") do
         {:ok, path} -> path
         _ -> Path.expand("excoveralls/lib/templates/html/htmlcov/", Mix.Project.deps_path())
       end

--- a/lib/excoveralls/json.ex
+++ b/lib/excoveralls/json.ex
@@ -22,7 +22,7 @@ defmodule ExCoveralls.Json do
 
   defp output_dir do
     options = ExCoveralls.Settings.get_coverage_options
-    case Dict.fetch(options, "output_dir") do
+    case Map.fetch(options, "output_dir") do
       {:ok, val} -> val
       _ -> "cover/"
     end

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -111,7 +111,7 @@ defmodule ExCoveralls.Local do
 
   defp default_coverage_value do
     options = ExCoveralls.Settings.get_coverage_options
-    case Dict.fetch(options, "treat_no_relevant_lines_as_covered") do
+    case Map.fetch(options, "treat_no_relevant_lines_as_covered") do
       {:ok, true} -> 100.0
       _           -> 0.0
     end

--- a/lib/excoveralls/settings.ex
+++ b/lib/excoveralls/settings.ex
@@ -29,7 +29,7 @@ defmodule ExCoveralls.Settings do
   Get default coverage value for lines marked as not relevant.
   """
   def default_coverage_value do
-    case Dict.fetch(get_coverage_options(), "treat_no_relevant_lines_as_covered") do
+    case Map.fetch(get_coverage_options(), "treat_no_relevant_lines_as_covered") do
       {:ok, true} -> 100.0
       _           -> 0.0
     end

--- a/lib/excoveralls/stat_server.ex
+++ b/lib/excoveralls/stat_server.ex
@@ -4,7 +4,7 @@ defmodule ExCoveralls.StatServer do
   """
 
   def start do
-    Agent.start(fn -> HashSet.new end, name: __MODULE__)
+    Agent.start(fn -> MapSet.new end, name: __MODULE__)
   end
 
   def stop do
@@ -12,7 +12,7 @@ defmodule ExCoveralls.StatServer do
   end
 
   def add(report) do
-    Agent.update(__MODULE__, &Set.put(&1, report))
+    Agent.update(__MODULE__, &MapSet.put(&1, report))
   end
 
   def get do

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Coveralls do
 
   defp analyze_sub_apps(options) do
     type = options[:type] || "local"
-    stats = ExCoveralls.StatServer.get |> Set.to_list
+    stats = ExCoveralls.StatServer.get |> MapSet.to_list
     ExCoveralls.analyze(stats, type, options)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExCoveralls.Mixfile do
   def project do
     [ app: :excoveralls,
       version: "0.5.7",
-      elixir: "~> 1.0",
+      elixir: "~> 1.2",
       deps: deps(),
       description: description(),
       package: package(),


### PR DESCRIPTION
This PR removes the deprecation for Dict Usage in favor of Map.

Dict has been deprecated since Elixir 1.2 as Erlang 1.8 got a huge performance boost on maps.

Map is now the favored data structure for maps.

See :

https://github.com/elixir-lang/elixir/blob/v1.2.0/CHANGELOG.md#erlang-18-support
https://hexdocs.pm/elixir/Map.html

Note : Map was officially deprecated in elixir 1.2.
I'm bumping the compatible version as it may fail on elixir 1.0 / 1.1 (these release are over 2-3 years old).

Thanks!