### PR TITLE
Use @preferred_cli_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ The followings are example projects.
 Add the following parameters.
 
 - `test_coverage: [tool: ExCoveralls]` for using ExCoveralls for coverage reporting.
-- `preferred_cli_env: [coveralls: :test]` for running `mix coveralls` in `:test` env by default
-    - It's an optional setting for skipping `MIX_ENV=test` part when executing `mix coveralls` tasks.
 - `test_coverage: [test_task: "espec"]` if you use Espec instead of default ExUnit.
 - `:excoveralls` in the deps function.
 
 ```elixir
 def project do
-  [ app: :excoveralls,
+  [
+    app: :excoveralls,
     version: "1.0.0",
     elixir: "~> 1.0.0",
     deps: deps(Mix.env),
     test_coverage: [tool: ExCoveralls],
-    preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
     # if you want to use espec,
     # test_coverage: [tool: ExCoveralls, test_task: "espec"]
   ]
 end
 
 defp deps do
-  [{:excoveralls, "~> 0.6", only: :test}]
+  [
+    {:excoveralls, "~> 0.6", only: :test}
+  ]
 end
 ```
 

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Coveralls do
   use Mix.Task
 
   @shortdoc "Display the test coverage"
+  @preferred_cli_env :test
 
   defmodule Runner do
     def run(task, args) do
@@ -96,6 +97,7 @@ defmodule Mix.Tasks.Coveralls do
     use Mix.Task
 
     @shortdoc "Display the test coverage with source detail"
+    @preferred_cli_env :test
 
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [ type: "local", detail: true ])
@@ -110,6 +112,7 @@ defmodule Mix.Tasks.Coveralls do
     use Mix.Task
 
     @shortdoc "Display the test coverage with source detail as an HTML report"
+    @preferred_cli_env :test
 
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [ type: "html" ])
@@ -124,6 +127,7 @@ defmodule Mix.Tasks.Coveralls do
     use Mix.Task
 
     @shortdoc "Output the test coverage as a JSON file"
+    @preferred_cli_env :test
 
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [ type: "json" ])
@@ -136,6 +140,8 @@ defmodule Mix.Tasks.Coveralls do
     """
     use Mix.Task
 
+    @preferred_cli_env :test
+
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [type: "travis"])
     end
@@ -147,6 +153,8 @@ defmodule Mix.Tasks.Coveralls do
     """
     use Mix.Task
 
+    @preferred_cli_env :test
+
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [type: "circle"])
     end
@@ -157,6 +165,8 @@ defmodule Mix.Tasks.Coveralls do
     Provides an entry point for SemaphoreCI's script.
     """
     use Mix.Task
+
+    @preferred_cli_env :test
 
     def run(args) do
       Mix.Tasks.Coveralls.do_run(args, [type: "semaphore"])
@@ -172,6 +182,7 @@ defmodule Mix.Tasks.Coveralls do
 
     @shortdoc "Post the test coverage to coveralls"
     @default_service_name "excoveralls"
+    @preferred_cli_env :test
 
     def run(args) do
       {options, params, _} =


### PR DESCRIPTION
Elixir provides the ability to use @preferred_cli_env directly on the task since version v1.3.0. This PR declares those attributes by default.

Keep in mind that:

  1. This won't work for Elixir versions earlier than v1.3.0. If you still support them, you may want to add the line about preferred_cli_env back to the README

  2. The README will be outdated as soon as this is merged, so you may want to consider a new release

Thank you! :heart: