### PR TITLE
do not force mix env when running tests

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -36,9 +36,6 @@ defmodule Mix.Tasks.Coveralls do
     {args, options} = parse_common_options(args, options)
     test_task = Mix.Project.config[:test_coverage][:test_task] || "test"
 
-    Mix.env(:test)
-
-
     options =
       if options[:umbrella] do
         sub_apps = ExCoveralls.SubApps.parse(Mix.Dep.Umbrella.loaded)


### PR DESCRIPTION
I have a build pipeline for a work project that builds a docker image with my app compiled with `MIX_ENV=prod`. Later on I run all the tests against this image. This prevented me from using `excoveralls` because it would try to set my `Mix.env(:test)` for my unit tests. Just skipping this call lets my tests run as expected (both `mix coveralls` and `mix test` run under the `prod` env).

I think this should be okay to do since you documentation in your project to tell people to use a preferred CLI env of `test`, so their unit tests will usually run with `Mix.env == :test`, but it will allow other use-cases like mine to work as well.

Maybe there's a reason this needs to be set? I tried searching the git history, but it looks like this has been here from the beginning of the projects so I wasn't sure why it might be needed.