### PR TITLE
Take the highest coverage count for a single line

### DIFF
--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -52,7 +52,7 @@ defmodule ExCoveralls.Stats do
   defp add_counts(module_hash, module, line, count) do
     path = Cover.module_path(module)
     count_hash = Map.get(module_hash, path, Map.new)
-    Map.put(module_hash, path, Map.put(count_hash, line, count))
+    Map.put(module_hash, path, Map.put(count_hash, line, max(Map.get(count_hash, line, 0), count)))
   end
 
   @doc """


### PR DESCRIPTION
In some cases the call to erlang's cover.analyse/3 will return more than
one result for the same line. Usually the coverage count is the same,
but in some cases (e.g. with schema definitions in an Ecto model) the
coverage count can alternate between different values, like 1 and 0, and
the line might be marked as covered or not depending on the order of
these results.

Investigations did not lead to a definite answer as to why this is
happening, but with this fix we will at least take the greatest coverage
count, instead of the latest, as the value for our report.

Fixes #84