### PR TITLE
Fix html template is ignoring template_path from options

### DIFF
--- a/lib/excoveralls/html/view.ex
+++ b/lib/excoveralls/html/view.ex
@@ -23,7 +23,9 @@ defmodule ExCoveralls.Html.View do
 
   @template "coverage.html.eex"
 
-  EEx.function_from_file(:def, :render, PathHelper.template_path(@template), [:assigns])
+  def render(assigns \\ []) do
+    EEx.eval_file(PathHelper.template_path(@template), assigns: assigns)
+  end
 
   def partial(template, assigns \\ []) do
     EEx.eval_file(PathHelper.template_path(template), assigns: assigns)

--- a/lib/templates/html/htmlcov/coverage.html.eex
+++ b/lib/templates/html/htmlcov/coverage.html.eex
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Coverage</title>
-    <%= partial "_style.html.eex" %>
-    <%= partial "_script.html.eex" %>
+    <%= ExCoveralls.Html.View.partial "_style.html.eex" %>
+    <%= ExCoveralls.Html.View.partial "_script.html.eex" %>
   </head>
   <body>
     <div id='coverage'>
@@ -12,7 +12,7 @@
         <li><a href='#overview'>overview</a></li>
         <%= for file <- @cov.files do %>
           <li>
-            <span class='cov <%= coverage_class(file.coverage) %>'><%= file.coverage || 0 %></span>
+            <span class='cov <%= ExCoveralls.Html.View.coverage_class(file.coverage) %>'><%= file.coverage || 0 %></span>
             <a href='#<%= file.filename %>'>
               <% parts = String.split(file.filename, "/") %><% [b | s] = parts |> Enum.reverse |> Enum.reverse_slice(1, Enum.count(parts)) %>
               <%= if Enum.count(s) do %>
@@ -24,7 +24,7 @@
         <% end %>
       </div>
 
-      <div id='stats' class='<%= coverage_class(@cov.coverage) %>'>
+      <div id='stats' class='<%= ExCoveralls.Html.View.coverage_class(@cov.coverage) %>'>
         <div class='percentage'><%= @cov.coverage || 0 %></div>
         <div class='sloc'><%= @cov.sloc %></div>
         <div class='hits'><%= @cov.hits %></div>
@@ -34,7 +34,7 @@
         <%= for file <- @cov.files do %>
           <div class='file'>
             <h2 id='<%= file.filename %>'><%= file.filename %></h1>
-            <div id='stats' class='<%= coverage_class(file.coverage) %>'>
+            <div id='stats' class='<%= ExCoveralls.Html.View.coverage_class(file.coverage) %>'>
               <div class='percentage'><%= file.coverage || 0 %></div>
               <div class='sloc'><%= file.sloc %></div>
               <div class='hits'><%= file.hits %></div>
@@ -54,19 +54,19 @@
                       <tr class='hit'>
                         <td class='line'><%= number %></td>
                         <td class='hits'><%= line.coverage %></td>
-                        <td class='source'><%= safe line.source %></td>
+                        <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
                       </tr>
                     <%= 0 == line.coverage -> %>
                       <tr class='miss'>
                         <td class='line'><%= number %></td>
                         <td class='hits'>0</td>
-                        <td class='source'><%= safe line.source %></td>
+                        <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
                       </tr>
                     <%= true -> %>
                       <tr>
                         <td class='line'><%= number %></td>
                         <td class='hits'></td>
-                        <td class='source'><%= safe(line.source || ' ')  %></td>
+                        <td class='source'><%= ExCoveralls.Html.View.safe(line.source || ' ')  %></td>
                       </tr>
                   <% end %>
                 <% end %>


### PR DESCRIPTION
**Problem:**

I wanted to set a custom template. This didn't work. I copied the template directory from the library and changes the contents. Strangely only the _script.html.eex and _style.html.eex customizations worked.

**Solution:**

After debugging, i found the issue.
The main template function `render` for the coverage.html.eex is evaluated during compile time. So template_path is only ignored for this template.  

In the patch I used `EEx.eval_file`. This is also used for the partial function.

