### PR TITLE
Fix to_char_list -> to_charlist deprecation

### DIFF
--- a/lib/excoveralls/cover.ex
+++ b/lib/excoveralls/cover.ex
@@ -9,7 +9,7 @@ defmodule ExCoveralls.Cover do
   def compile(compile_path) do
     :cover.stop
     :cover.start
-    :cover.compile_beam_directory(compile_path |> String.to_char_list)
+    :cover.compile_beam_directory(compile_path |> string_to_charlist)
   end
 
   @doc """
@@ -39,5 +39,11 @@ defmodule ExCoveralls.Cover do
   @doc "Wrapper for :cover.analyse"
   def analyze(module) do
     :cover.analyse(module, :calls, :line)
+  end
+
+  if Version.compare(System.version, "1.3.0") == :lt do
+    defp string_to_charlist(string), do: String.to_char_list(string)
+  else
+    defp string_to_charlist(string), do: String.to_charlist(string)
   end
 end

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -103,7 +103,7 @@ defmodule ExCoveralls.Stats do
   end
 
   defp count_lines(string) do
-    1 + Enum.count(String.to_char_list(string), fn(x) -> x == ?\n end)
+    1 + Enum.count(string_to_charlist(string), fn(x) -> x == ?\n end)
   end
 
   @doc """
@@ -220,4 +220,9 @@ defmodule ExCoveralls.Stats do
     end
   end
 
+  if Version.compare(System.version, "1.3.0") == :lt do
+    defp string_to_charlist(string), do: String.to_char_list(string)
+  else
+    defp string_to_charlist(string), do: String.to_charlist(string)
+  end
 end


### PR DESCRIPTION
This uses conditional compilation á la [decimal](https://github.com/ericmj/decimal/blob/master/lib/decimal.ex#L1475-L1480) to stay compatible while silence the warning.

https://hexdocs.pm/elixir/deprecations.html