### PR TITLE
Changes the behavior of mix coveralls.post so that it recognizes

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -182,9 +182,12 @@ defmodule Mix.Tasks.Coveralls do
     @preferred_cli_env :test
 
     def run(args) do
+      switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean]
+      aliases = [f: :filter, u: :umbrella, v: :verbose]
       {options, params, _} =
         OptionParser.parse(args,
-          aliases: [n: :name, b: :branch, c: :committer, m: :message, s: :sha, t: :token])
+          switches: switches,
+          aliases: aliases ++ [n: :name, b: :branch, c: :committer, m: :message, s: :sha, t: :token])
 
       Mix.Tasks.Coveralls.do_run(params,
         [ type:         "post",
@@ -194,7 +197,10 @@ defmodule Mix.Tasks.Coveralls do
           branch:       options[:branch] || "",
           committer:    options[:committer] || "",
           sha:          options[:sha] || "",
-          message:      options[:message] || "[no commit message]" ])
+          message:      options[:message] || "[no commit message]",
+          umbrella:     options[:umbrella],
+          verbose:      options[:verbose]
+        ])
     end
 
     def extract_service_name(options) do

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -134,7 +134,8 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
               service_name: "dummy_service_name", branch: "branch",
-              committer: "committer", sha: "asdf", message: "message", args: []])
+              committer: "committer", sha: "asdf", message: "message",
+              umbrella: nil, verbose: nil, args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
@@ -153,7 +154,8 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "token",
               service_name: "excoveralls", branch: "",
-              committer: "", sha: "", message: "[no commit message]", args: []])
+              committer: "", sha: "", message: "[no commit message]",
+              umbrella: nil, verbose: nil, args: []])
 
     if org_token != nil do
       System.put_env("COVERALLS_REPO_TOKEN", org_token)


### PR DESCRIPTION
that coverage is being run against an umbrella app and only posts
to coveralls.io once all sub-applications have been analysed

Fixes #76 

Prior to this change, `Poster.execute/2` was getting called after every sub application's coverage was calculated. Now, it only gets called once at the end of the last sub application's coverage run.

The excoveralls.post.json file that is sent to coveralls.io contains all of the files from all sub-applications and the reported coverage number in coveralls.io now matches that produced in the summary line when running:

`mix coveralls --umbrella`