### PR TITLE
added support for ~/.excoversalls/coveralls.json

### DIFF
--- a/lib/excoveralls/settings.ex
+++ b/lib/excoveralls/settings.ex
@@ -6,7 +6,10 @@ defmodule ExCoveralls.Settings do
   defmodule Files do
     @file_name "coveralls.json"
     def default_file, do: "#{Path.dirname(__ENV__.file)}/../conf/#{@file_name}"
-    def custom_file,  do: "#{System.cwd}/#{@file_name}"
+    def custom_file do
+      dot_file = Path.expand("~/.excoveralls/coveralls.json")
+      if File.exists?(dot_file), do: dot_file, else: "#{System.cwd}/#{@file_name}"
+    end
   end
 
   @doc """


### PR DESCRIPTION
I was looking for a way to use my own custom config and templates for all my projects.
To accomplish this I've changed the custom_file to first check if  ~/.excoveralls/coveralls.json  exists and if so, use that, if not check if coveralls.json exists in the project, otherwise use the default one from the package.

In my case I've created a custom template which I store in ~/.excoveralls/templates/html/htmlcov which uses a custom theme, highlight.js, firacode and hides all files in preview that are already 100% covered.

my config looks like:
```json
{
  "coverage_options": {
    "template_path": "~/.excoveralls/templates/html/htmlcov"
  }
}
```

example output:

![example](https://cl.ly/1i3A0X110S2D/Image%202017-11-09%20at%2010.05.49%20AM.png)

If you are interested in the template, you can find it here : https://github.com/smeevil/excoveralls_dark_template

Hopefully you'll find this a useful addition, if not, please let me know if you have an other suggestion to achieve this. 

Gerard.

This also take case of issue #81 opened by @freiden