### PR TITLE
add --sort option to Local runner

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   defp parse_common_options(args, options) do
-    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean]
+    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string]
     aliases = [f: :filter, u: :umbrella, v: :verbose]
     {common_options, _remaining, _invalid} = OptionParser.parse(args, switches: switches, aliases: aliases)
 


### PR DESCRIPTION
Still would like to get some tests around it as well as update the docs/help banner

Adds a `--sort` option to the local runner. The option can take one or more fields and with explicit sort direction. Sorting is stable and prioritizes the first sort option

Ex:

```
$ mix coveralls --sort cov
----------------
COV    FILE                                        LINES RELEVANT   MISSED
100.0% lib/excoveralls/exceptions.ex                  11        0        0
100.0% lib/excoveralls/html/safe.ex                   28        2        0
100.0% lib/excoveralls/path_reader.ex                 20        2        0
100.0% lib/excoveralls/stat_server.ex                 21        4        0
100.0% lib/excoveralls/stop_words.ex                  37        7        0
100.0% lib/excoveralls/sub_apps.ex                    21        5        0
100.0% lib/excoveralls/task/util.ex                   43        1        0
 88.9% lib/excoveralls/conf_server.ex                 44        9        1
 85.7% lib/excoveralls/poster.ex                      47       14        2
 81.8% lib/excoveralls/html/view.ex                   46       11        2
 77.3% lib/excoveralls/local.ex                      194       66       15
 75.0% lib/excoveralls/settings.ex                    92       20        5
 73.3% lib/excoveralls/circle.ex                      72       15        4
 71.4% lib/excoveralls/semaphore.ex                   67       14        4
 65.6% lib/excoveralls/stats.ex                      228       61       21
 60.0% lib/excoveralls/travis.ex                      51       10        4
 45.5% lib/excoveralls/cover.ex                       49       11        6
 20.0% lib/excoveralls/post.ex                        33        5        4
 14.3% lib/mix/tasks.ex                              218       49       42
  5.6% lib/excoveralls.ex                            105       18       17
  0.0% lib/excoveralls/html.ex                        43       12       12
  0.0% lib/excoveralls/json.ex                        39       10       10
[TOTAL]  56.9%
----------------

$ mix coveralls --sort cov:asc
----------------
COV    FILE                                        LINES RELEVANT   MISSED
  0.0% lib/excoveralls/html.ex                        43       12       12
  0.0% lib/excoveralls/json.ex                        39       10       10
  5.6% lib/excoveralls.ex                            105       18       17
 14.3% lib/mix/tasks.ex                              218       49       42
 20.0% lib/excoveralls/post.ex                        33        5        4
 45.5% lib/excoveralls/cover.ex                       49       11        6
 60.0% lib/excoveralls/travis.ex                      51       10        4
 65.6% lib/excoveralls/stats.ex                      228       61       21
 71.4% lib/excoveralls/semaphore.ex                   67       14        4
 73.3% lib/excoveralls/circle.ex                      72       15        4
 75.0% lib/excoveralls/settings.ex                    92       20        5
 77.3% lib/excoveralls/local.ex                      194       66       15
 81.8% lib/excoveralls/html/view.ex                   46       11        2
 85.7% lib/excoveralls/poster.ex                      47       14        2
 88.9% lib/excoveralls/conf_server.ex                 44        9        1
100.0% lib/excoveralls/exceptions.ex                  11        0        0
100.0% lib/excoveralls/html/safe.ex                   28        2        0
100.0% lib/excoveralls/path_reader.ex                 20        2        0
100.0% lib/excoveralls/stat_server.ex                 21        4        0
100.0% lib/excoveralls/stop_words.ex                  37        7        0
100.0% lib/excoveralls/sub_apps.ex                    21        5        0
100.0% lib/excoveralls/task/util.ex                   43        1        0
[TOTAL]  56.9%
----------------

$ mix coveralls --sort cov:asc,lines:asc
----------------
COV    FILE                                        LINES RELEVANT   MISSED
  0.0% lib/excoveralls/json.ex                        39       10       10
  0.0% lib/excoveralls/html.ex                        43       12       12
  5.6% lib/excoveralls.ex                            105       18       17
 14.3% lib/mix/tasks.ex                              218       49       42
 20.0% lib/excoveralls/post.ex                        33        5        4
 45.5% lib/excoveralls/cover.ex                       49       11        6
 60.0% lib/excoveralls/travis.ex                      51       10        4
 65.6% lib/excoveralls/stats.ex                      228       61       21
 71.4% lib/excoveralls/semaphore.ex                   67       14        4
 73.3% lib/excoveralls/circle.ex                      72       15        4
 75.0% lib/excoveralls/settings.ex                    92       20        5
 77.3% lib/excoveralls/local.ex                      194       66       15
 81.8% lib/excoveralls/html/view.ex                   46       11        2
 85.7% lib/excoveralls/poster.ex                      47       14        2
 88.9% lib/excoveralls/conf_server.ex                 44        9        1
100.0% lib/excoveralls/exceptions.ex                  11        0        0
100.0% lib/excoveralls/path_reader.ex                 20        2        0
100.0% lib/excoveralls/stat_server.ex                 21        4        0
100.0% lib/excoveralls/sub_apps.ex                    21        5        0
100.0% lib/excoveralls/html/safe.ex                   28        2        0
100.0% lib/excoveralls/stop_words.ex                  37        7        0
100.0% lib/excoveralls/task/util.ex                   43        1        0
[TOTAL]  56.9%
----------------
```