### PR TITLE
Ensure missing source from dirty build dir is not reported

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -7,5 +7,9 @@
     "output_dir": "cover/",
     "template_path": "lib/templates/html/htmlcov/",
     "minimum_coverage": 0
-  }
+  },
+
+  "skip_files": [
+    "test/fixtures/test_missing.ex"
+  ]
 }

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule ExCoveralls.Mixfile do
     [ app: :excoveralls,
       version: "0.8.1",
       elixir: "~> 1.2",
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),
       package: package(),
@@ -23,6 +24,10 @@ defmodule ExCoveralls.Mixfile do
   def application do
     []
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/fixtures/test_missing.ex"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Returns the list of dependencies in the format:
   # { :foobar, "~> 0.1", git: "https://github.com/elixir-lang/foobar.git" }

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -1,8 +1,38 @@
 defmodule CoverTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
   alias ExCoveralls.Cover
 
   test "module path returns relative path" do
     assert(Cover.module_path(ExCoveralls) == "lib/excoveralls.ex")
+  end
+
+  test "has_compile_info?/1 with uncompiled module raises warning and returns false" do
+    assert capture_io(:stderr, fn ->
+      refute Cover.has_compile_info?(Foo)
+    end) =~ "[warning] skipping the module 'Elixir.Foo' because source information for the module is not available."
+  end
+
+  test "has_compile_info?/1 with missing source file raises warning and returns false" do
+    assert Cover.has_compile_info?(TestMissing)
+
+    path = Cover.module_path(TestMissing)
+    backup_path = "test/fixtures/test_missing.bkp"
+    on_exit({:clean_up, backup_path}, fn ->
+      File.copy!(backup_path, path)
+      File.rm!(backup_path)
+    end)
+
+    File.copy!(path, backup_path)
+    File.rm!(path)
+    refute File.exists?(path)
+
+    assert capture_io(:stderr, fn ->
+      refute Cover.has_compile_info?(TestMissing)
+    end) =~ "[warning] skipping the module 'Elixir.TestMissing' because source information for the module is not available."
+  end
+
+  test "has_compile_info?/1 with existing source returns true" do
+    assert Cover.has_compile_info?(TestMissing)
   end
 end

--- a/test/fixtures/test_missing.ex
+++ b/test/fixtures/test_missing.ex
@@ -1,0 +1,4 @@
+defmodule TestMissing do
+  def test do
+  end
+end


### PR DESCRIPTION
This change introduces a check in the `Cover` module to verify the related source for a compiled module is still present. Missing source files are a common issue for CI builds with cached build paths, where later commits have removed or renamed a file.

If the source is not present, the module is skipped in stats reporting and a warning is logged. This ensures previously compiled modules that may no longer exist will not cause the build to exit with an error status, yet still provide visibility on missing modules.

Resolves: #55 