### PR TITLE
fixed pattern matching in ExCoveralls.Local.colorize/1

### DIFF
--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -54,7 +54,7 @@ defmodule ExCoveralls.Local do
     "\n\e[33m--------#{stat[:name]}--------\e[m\n" <> colorize(stat)
   end
 
-  defp colorize([{:name, _name}, {:source, source}, {:coverage, coverage}]) do
+  defp colorize(%{source: source, coverage: coverage}) do
     lines = String.split(source, "\n")
     Enum.zip(lines, coverage)
     |> Enum.map(&do_colorize/1)
@@ -191,4 +191,3 @@ defmodule ExCoveralls.Local do
     List.to_string(char_list)
   end
 end
-

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -6,22 +6,22 @@ defmodule ExCoveralls.LocalTest do
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil]
-  @source_info [[name: "test/fixtures/test.ex",
+  @source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @counts
-               ]]
+               }]
 
   @invalid_counts [0, 1, nil, "invalid"]
-  @invalid_source_info [[name: "test/fixtures/test.ex",
+  @invalid_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @invalid_counts
-               ]]
+               }]
 
   @empty_counts [nil, nil, nil, nil]
-  @empty_source_info [[name: "test/fixtures/test.ex",
+  @empty_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @empty_counts
-               ]]
+               }]
 
   @stats_result "" <>
       "----------------\n" <>
@@ -95,4 +95,3 @@ defmodule ExCoveralls.LocalTest do
     end) =~ @stats_result
   end
 end
-


### PR DESCRIPTION
invalid pattern causes MatchError after upgrading from 0.8.x to 0.9.0