### PR TITLE
Fix uncaught FunctionClauseError

### DIFF
--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -78,11 +78,11 @@ defmodule ExCoveralls.Stats do
   """
   def generate_source_info(coverage) do
     Enum.map(coverage, fn({file_path, stats}) ->
-      [
+      %{
         name: file_path,
         source: read_source(file_path),
         coverage: stats
-      ]
+      }
     end)
   end
 
@@ -90,7 +90,9 @@ defmodule ExCoveralls.Stats do
   Append the name of the sub app to the source info stats.
   """
   def append_sub_app_name(stats, sub_app_name, apps_path) do
-    Enum.map(stats, &expand_name(apps_path, sub_app_name, &1))
+    Enum.map(stats, fn(%{name: name, source: source, coverage: coverage}) ->
+      [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
+    end)
   end
 
   @doc """
@@ -216,13 +218,6 @@ defmodule ExCoveralls.Stats do
       IO.puts IO.ANSI.format([:red, :bright, message])
       exit({:shutdown, 1})
     end
-  end
-
-  defp expand_name(apps_path, sub_app_name, %{name: name, source: source, coverage: coverage}) do
-    [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
-  end
-  defp expand_name(apps_path, sub_app_name, [{:name, name}, {:source, source}, {:coverage, coverage}]) do
-    [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
   end
 
   if Version.compare(System.version, "1.3.0") == :lt do

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -90,9 +90,7 @@ defmodule ExCoveralls.Stats do
   Append the name of the sub app to the source info stats.
   """
   def append_sub_app_name(stats, sub_app_name, apps_path) do
-    Enum.map(stats, fn([{:name, name}, {:source, source}, {:coverage, coverage}]) ->
-      [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
-    end)
+    Enum.map(stats, &expand_name(apps_path, sub_app_name, &1))
   end
 
   @doc """
@@ -218,6 +216,13 @@ defmodule ExCoveralls.Stats do
       IO.puts IO.ANSI.format([:red, :bright, message])
       exit({:shutdown, 1})
     end
+  end
+
+  defp expand_name(apps_path, sub_app_name, %{name: name, source: source, coverage: coverage}) do
+    [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
+  end
+  defp expand_name(apps_path, sub_app_name, [{:name, name}, {:source, source}, {:coverage, coverage}]) do
+    [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
   end
 
   if Version.compare(System.version, "1.3.0") == :lt do

--- a/lib/excoveralls/stop_words.ex
+++ b/lib/excoveralls/stop_words.ex
@@ -10,14 +10,14 @@ defmodule ExCoveralls.StopWords do
     Enum.map(info, fn(x) -> do_filter(x, words) end)
   end
 
-  defp do_filter([{:name, name}, {:source, source}, {:coverage, coverage}], words) do
+  defp do_filter(%{name: name, source: source, coverage: coverage}, words) do
     lines = String.split(source, "\n")
     list = Enum.zip(lines, coverage)
            |> Enum.map(fn(x) -> has_valid_line?(x, words) end)
            |> List.zip
            |> Enum.map(&Tuple.to_list(&1))
     [source, coverage] = parse_filter_list(list)
-    [name: name, source: source, coverage: coverage]
+    %{name: name, source: source, coverage: coverage}
   end
 
   defp parse_filter_list([]),   do: ["", []]

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -13,10 +13,7 @@ defmodule ExCoveralls.StatsTest do
   @module_hash     Enum.into([{"test/fixtures/test.ex", @count_hash}], Map.new)
   @counts          [0, 1, nil, nil]
   @coverage        [{"test/fixtures/test.ex", @counts}]
-  @source_info     [[name: "test/fixtures/test.ex",
-                     source: @trimmed,
-                     coverage: @counts
-                   ]]
+  @source_info     [%{name: "test/fixtures/test.ex", source: @trimmed, coverage: @counts}]
   @fixture_default Path.dirname(__ENV__.file) <> "/fixtures/default.json"
   @fixture_custom  Path.dirname(__ENV__.file) <> "/fixtures/skip_files.json"
 

--- a/test/stop_words_test.exs
+++ b/test/stop_words_test.exs
@@ -4,10 +4,7 @@ defmodule ExCoveralls.StopWordsTest do
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil, nil]
-  @source_info [[name: "test/fixtures/test.ex",
-                 source: @content,
-                 coverage: @counts
-               ]]
+  @source_info [%{name: "test/fixtures/test.ex", source: @content, coverage: @counts}]
 
   test "filter stop words returns valid list" do
     info = StopWords.filter(@source_info, ["defmodule", "end"]) |> Enum.at(0)


### PR DESCRIPTION
Great project. Thank you.

I was getting a stack trace on my umbrella app:

```
** (FunctionClauseError) no function clause matching in anonymous fn/1 in ExCoveralls.Stats.append_sub_app_name/3
  |  
  | The following arguments were given to anonymous fn/1 in ExCoveralls.Stats.append_sub_app_name/3:
  |  
  | # 1
  | %{coverage: [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil], name: "lib/myapp/mymodule.ex", source: "defmodule  ... snip ..."}
  |  
  | lib/excoveralls/stats.ex:93: anonymous fn/1 in ExCoveralls.Stats.append_sub_app_name/3
  | (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
 
```
