### PR TITLE
Fix umbrella stats and make source consistent

### DIFF
--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -54,7 +54,7 @@ defmodule ExCoveralls.Local do
     "\n\e[33m--------#{stat[:name]}--------\e[m\n" <> colorize(stat)
   end
 
-  defp colorize([{:name, _name}, {:source, source}, {:coverage, coverage}]) do
+  defp colorize(%{name: _name, source: source, coverage: coverage}) do
     lines = String.split(source, "\n")
     Enum.zip(lines, coverage)
     |> Enum.map(&do_colorize/1)
@@ -191,4 +191,3 @@ defmodule ExCoveralls.Local do
     List.to_string(char_list)
   end
 end
-

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -78,11 +78,11 @@ defmodule ExCoveralls.Stats do
   """
   def generate_source_info(coverage) do
     Enum.map(coverage, fn({file_path, stats}) ->
-      [
+      %{
         name: file_path,
         source: read_source(file_path),
         coverage: stats
-      ]
+      }
     end)
   end
 
@@ -90,8 +90,8 @@ defmodule ExCoveralls.Stats do
   Append the name of the sub app to the source info stats.
   """
   def append_sub_app_name(stats, sub_app_name, apps_path) do
-    Enum.map(stats, fn([{:name, name}, {:source, source}, {:coverage, coverage}]) ->
-      [{:name, "#{apps_path}/#{sub_app_name}/#{name}"}, {:source, source}, {:coverage, coverage}]
+    Enum.map(stats, fn %{name: name} = stat ->
+      %{stat | name: "#{apps_path}/#{sub_app_name}/#{name}"}
     end)
   end
 

--- a/lib/excoveralls/stop_words.ex
+++ b/lib/excoveralls/stop_words.ex
@@ -10,14 +10,14 @@ defmodule ExCoveralls.StopWords do
     Enum.map(info, fn(x) -> do_filter(x, words) end)
   end
 
-  defp do_filter([{:name, name}, {:source, source}, {:coverage, coverage}], words) do
+  defp do_filter(%{name: name, source: source, coverage: coverage}, words) do
     lines = String.split(source, "\n")
     list = Enum.zip(lines, coverage)
            |> Enum.map(fn(x) -> has_valid_line?(x, words) end)
            |> List.zip
            |> Enum.map(&Tuple.to_list(&1))
     [source, coverage] = parse_filter_list(list)
-    [name: name, source: source, coverage: coverage]
+    %{name: name, source: source, coverage: coverage}
   end
 
   defp parse_filter_list([]),   do: ["", []]

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -11,10 +11,10 @@ defmodule ExCoveralls.HtmlTest do
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil]
-  @source_info [[name: "test/fixtures/test.ex",
+  @source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @counts
-               ]]
+               }]
 
   @stats_result "" <>
     "----------------\n" <>
@@ -75,4 +75,3 @@ defmodule ExCoveralls.HtmlTest do
   end
 
 end
-

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -6,22 +6,22 @@ defmodule ExCoveralls.LocalTest do
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil]
-  @source_info [[name: "test/fixtures/test.ex",
+  @source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @counts
-               ]]
+               }]
 
   @invalid_counts [0, 1, nil, "invalid"]
-  @invalid_source_info [[name: "test/fixtures/test.ex",
+  @invalid_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @invalid_counts
-               ]]
+               }]
 
   @empty_counts [nil, nil, nil, nil]
-  @empty_source_info [[name: "test/fixtures/test.ex",
+  @empty_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @empty_counts
-               ]]
+               }]
 
   @stats_result "" <>
       "----------------\n" <>
@@ -95,4 +95,3 @@ defmodule ExCoveralls.LocalTest do
     end) =~ @stats_result
   end
 end
-

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -13,24 +13,24 @@ defmodule ExCoveralls.StatsTest do
   @module_hash     Enum.into([{"test/fixtures/test.ex", @count_hash}], Map.new)
   @counts          [0, 1, nil, nil]
   @coverage        [{"test/fixtures/test.ex", @counts}]
-  @source_info     [[name: "test/fixtures/test.ex",
+  @source_info     [%{name: "test/fixtures/test.ex",
                      source: @trimmed,
                      coverage: @counts
-                   ]]
+                   }]
   @fixture_default Path.dirname(__ENV__.file) <> "/fixtures/default.json"
   @fixture_custom  Path.dirname(__ENV__.file) <> "/fixtures/skip_files.json"
 
   @invalid_counts [0, 1, nil, "invalid"]
-  @invalid_source_info [[name: "test/fixtures/test.ex",
+  @invalid_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @invalid_counts
-               ]]
+               }]
 
   @empty_counts [nil, nil, nil, nil]
-  @empty_source_info [[name: "test/fixtures/test.ex",
+  @empty_source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @empty_counts
-               ]]
+               }]
 
   @source_result %{
     coverage: 50,

--- a/test/stop_words_test.exs
+++ b/test/stop_words_test.exs
@@ -4,10 +4,10 @@ defmodule ExCoveralls.StopWordsTest do
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil, nil]
-  @source_info [[name: "test/fixtures/test.ex",
+  @source_info [%{name: "test/fixtures/test.ex",
                  source: @content,
                  coverage: @counts
-               ]]
+               }]
 
   test "filter stop words returns valid list" do
     info = StopWords.filter(@source_info, ["defmodule", "end"]) |> Enum.at(0)


### PR DESCRIPTION
This change covers all the tests and areas I could find affected by https://github.com/parroty/excoveralls/commit/c1fdf4142f5e86094fa7512f5b2675649fa1f9f4.

Resolves #140