### PR TITLE
pass switches to OptionParser.parse opts

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   def run(args) do
-    {options, _, _} = OptionParser.parse(args, aliases: [h: :help])
+    {options, _, _} = OptionParser.parse(args, switches: [help: :boolean], aliases: [h: :help])
 
     if options[:help] do
       ExCoveralls.Task.Util.print_help_message


### PR DESCRIPTION
this gets rid of warning on elixir 1.7

```
warning: not passing the :switches or :strict option to OptionParser is deprecated
  (elixir) lib/option_parser.ex:562: OptionParser.build_config/1
  (elixir) lib/option_parser.ex:197: OptionParser.parse/2
  lib/mix/tasks.ex:18: Mix.Tasks.Coveralls.run/1
  (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
  (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```