### PR TITLE
Custom config file path, and ability to silence output

### DIFF
--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -43,11 +43,15 @@ defmodule ExCoveralls.Local do
   Prints summary statistics for given coverage.
   """
   def print_summary(stats, options \\ []) do
-    file_width = ExCoveralls.Settings.get_file_col_width
-    IO.puts "----------------"
-    IO.puts print_string("~-6s ~-#{file_width}s ~8s ~8s ~8s", ["COV", "FILE", "LINES", "RELEVANT", "MISSED"])
-    coverage(stats, options) |> IO.puts
-    IO.puts "----------------"
+    enabled = ExCoveralls.Settings.get_print_summary
+
+    if enabled do
+      file_width = ExCoveralls.Settings.get_file_col_width
+      IO.puts "----------------"
+      IO.puts print_string("~-6s ~-#{file_width}s ~8s ~8s ~8s", ["COV", "FILE", "LINES", "RELEVANT", "MISSED"])
+      coverage(stats, options) |> IO.puts
+      IO.puts "----------------"
+    end
   end
 
   defp format_source(stat) do

--- a/lib/excoveralls/settings.ex
+++ b/lib/excoveralls/settings.ex
@@ -6,7 +6,7 @@ defmodule ExCoveralls.Settings do
   defmodule Files do
     @filename "coveralls.json"
     def default_file, do: "#{Path.dirname(__ENV__.file)}/../conf/#{@filename}"
-    def custom_file, do: "#{System.cwd}/#{@filename}"
+    def custom_file, do: Application.get_env(:excoveralls, :config_file, "#{System.cwd}/#{@filename}")
     def dot_file, do: Path.expand("~/.excoveralls/#{@filename}")
   end
 
@@ -77,6 +77,10 @@ defmodule ExCoveralls.Settings do
     |> Enum.map(&Regex.compile!/1)
   end
 
+  def get_print_summary do
+    read_config("print_summary", true)
+  end
+
   @doc """
   Reads the value for the specified key defined in the json file.
   """
@@ -88,9 +92,8 @@ defmodule ExCoveralls.Settings do
   end
 
   defp read_merged_config(dot, custom) do
-    dot_config = read_config_file(dot)
-    project_config = read_config_file(custom)
-    merge(dot_config, project_config)
+    read_config_file(dot)
+    |> merge(read_config_file(custom))
   end
 
   defp merge(left, right) when is_map(left) and is_map(right) do

--- a/test/fixtures/no_summary.json
+++ b/test/fixtures/no_summary.json
@@ -1,0 +1,3 @@
+{
+  "print_summary": false
+}

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -40,7 +40,7 @@ defmodule ExCoveralls.HtmlTest do
   end
 
   test_with_mock "generate stats information", %{report: report}, ExCoveralls.Settings, [],
-    [get_coverage_options: fn -> %{"output_dir" => @test_output_dir, "template_path" => @test_template_path} end, get_file_col_width: fn -> 40 end] do
+  [get_coverage_options: fn -> %{"output_dir" => @test_output_dir, "template_path" => @test_template_path} end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
 
     assert capture_io(fn ->
       Html.execute(@source_info)
@@ -52,7 +52,7 @@ defmodule ExCoveralls.HtmlTest do
   end
 
   test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
-    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(100) end, get_file_col_width: fn -> 40 end] do
+    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(100) end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
     output = capture_io(fn ->
       assert catch_exit(Html.execute(@source_info)) == {:shutdown, 1}
     end)
@@ -60,7 +60,7 @@ defmodule ExCoveralls.HtmlTest do
   end
 
   test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
-    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(49.9) end, get_file_col_width: fn -> 40 end] do
+    ExCoveralls.Settings, [get_coverage_options: fn -> coverage_options(49.9) end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
     assert capture_io(fn ->
       Html.execute(@source_info)
     end) =~ @stats_result

--- a/test/json_test.exs
+++ b/test/json_test.exs
@@ -39,7 +39,7 @@ defmodule ExCoveralls.JsonTest do
   end
 
   test_with_mock "generate json file", %{report: report}, ExCoveralls.Settings, [],
-    [get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end, get_file_col_width: fn -> 40 end] do
+    [get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
 
     assert capture_io(fn ->
       Json.execute(@source_info)

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -81,7 +81,7 @@ defmodule ExCoveralls.LocalTest do
   end
 
   test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
-    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 100} end, get_file_col_width: fn -> 40 end] do
+    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 100} end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
     output = capture_io(fn ->
       assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
     end)
@@ -89,9 +89,16 @@ defmodule ExCoveralls.LocalTest do
   end
 
   test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
-    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end, get_file_col_width: fn -> 40 end] do
+    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
     assert capture_io(fn ->
       Local.execute(@source_info)
     end) =~ @stats_result
+  end
+
+  test_with_mock "No output if print_summary is false",
+    ExCoveralls.Settings, [get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end, get_file_col_width: fn -> 40 end, get_print_summary: fn -> true end] do
+    assert capture_io(fn ->
+      Local.execute(@source_info)
+    end) =~ ""
   end
 end

--- a/test/settings_test.exs
+++ b/test/settings_test.exs
@@ -11,6 +11,7 @@ defmodule Excoveralls.SettingsTest do
   @fixture_covered Path.dirname(__ENV__.file) <> "/fixtures/no_relevant_lines_are_covered.json"
   @fixture_column_default Path.dirname(__ENV__.file) <> "/fixtures/terminal_options1.json"
   @fixture_column_integer Path.dirname(__ENV__.file) <> "/fixtures/terminal_options2.json"
+  @fixture_no_summary Path.dirname(__ENV__.file) <> "/fixtures/no_summary.json"
 
   test "returns default file path" do
     assert(Settings.Files.default_file
@@ -20,6 +21,15 @@ defmodule Excoveralls.SettingsTest do
   test "returns custom file path" do
     assert(Settings.Files.custom_file
            |> Path.relative_to(File.cwd!) == "coveralls.json")
+  end
+
+  test "returns custom file path from config file" do
+    Application.put_env(:excoveralls, :config_file, "custom_coveralls.json")
+
+    assert(Settings.Files.custom_file
+           |> Path.relative_to(File.cwd!) == "custom_coveralls.json")
+
+    Application.delete_env(:excoveralls, :config_file)
   end
 
   test_with_mock "read config defined in default file", Settings.Files,
@@ -106,6 +116,26 @@ defmodule Excoveralls.SettingsTest do
     ] do
     assert Settings.default_coverage_value == 0
     assert Settings.get_stop_words()== [~r/a/, ~r/b/, ~r/cc/, ~r/dd/, ~r/aa/, ~r/bb/]
+  end
+
+  test_with_mock "print_summary is true by default",
+    Settings.Files, [
+      default_file: fn -> "__invalid__" end,
+      custom_file:  fn -> "__invalid__" end,
+      dot_file: fn -> "__invalid__" end
+    ] do
+
+    assert Settings.get_print_summary
+  end
+
+  test_with_mock "print_summary can be set to false",
+    Settings.Files, [
+      default_file: fn -> "__invalid__" end,
+      custom_file:  fn -> @fixture_no_summary end,
+      dot_file: fn -> "__invalid__" end
+    ] do
+
+    refute Settings.get_print_summary
   end
 
 end


### PR DESCRIPTION
I wanted to silence the output made by this package. `ExCoveralls.Local.print_summary` was being called unconditionally, regardless of the output mode selected.
This clutters our CI output and makes it a bit harder to parse.

So I added a `print_summary` option, which defaults to true, to keep the old behaviour.

Additionally, since I'm using an umbrella app, and I didn't want to add a `coveralls.json` file to all my apps, I also added a config option to set a different file. Now, I can have a global config file for the whole umbrella, with:

```
config :excoveralls,
  config_file: "#{System.cwd}/coveralls.json"
```

This seems to be the same value, but `System.cwd`, in this case runs in the context of the umbrella path, whereas the default one set from `Settings.Files.custom_file` runs in the context of each app