### PR TITLE
Add support for drone CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ end
 - [mix coveralls.travis](#mix-coverallstravis-post-coverage-from-travis)
 - [mix coveralls.circle](#mix-coverallscircle-post-coverage-from-circle)
 - [mix coveralls.semaphore](#mix-coverallssemaphore-post-coverage-from-semaphore)
+- [mix coveralls.drone](#mix-coverallsdrone-post-coverage-from-drone)
 - [mix coveralls.post](#mix-coverallspost-post-coverage-from-any-host)
 - [mix coveralls.detail](#mix-coverallsdetail-show-coverage-with-detail)
 - [mix coveralls.html](#mix-coverallshtml-show-coverage-as-html-report)
@@ -154,6 +155,23 @@ variable.
 ### [mix coveralls.semaphore] Post coverage from semaphore
 Specify `mix coveralls.semaphore` in the build command prompt for instructions in semaphore.
 This task is for submitting the result to the coveralls server when Semaphore-CI build is executed.
+
+### [mix coveralls.drone] Post coverage from drone
+Specify `mix coveralls.drone` in the `.drone.yml`.
+This task is for submitting the result to the coveralls server when the Drone build is executed.
+
+You will also need to add your coveralls repo token as a secret to the drone project:
+`drone secret add --repository=your-namespace/your-project --name=coveralls_repo_token --value=xyz`
+
+#### .drone.yml
+
+```yml
+pipeline:
+  build:
+    secrets: [ coveralls_repo_token ]
+    commands:
+      - mix coveralls.drone
+```
 
 #### semaphore build instructions
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following are example projects.
   - [semaphore_sample](https://github.com/parroty/semaphore_sample) is for Semaphore CI.
   - [excoveralls_umbrella](https://github.com/parroty/excoveralls_umbrella) is for umbrella project.
   - [gitlab_sample](https://gitlab.com/parroty/gitlab_sample) is for GitLab CI (using GitLab CI feature instead of coveralls.io).
+  - [drone_sample](https://github.com/vorce/drone_sample) is for Drone CI.
 
 # Settings
 ### mix.exs

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -10,6 +10,7 @@ defmodule ExCoveralls do
   alias ExCoveralls.Travis
   alias ExCoveralls.Circle
   alias ExCoveralls.Semaphore
+  alias ExCoveralls.Drone
   alias ExCoveralls.Local
   alias ExCoveralls.Html
   alias ExCoveralls.Json
@@ -18,6 +19,7 @@ defmodule ExCoveralls do
   @type_travis      "travis"
   @type_circle      "circle"
   @type_semaphore   "semaphore"
+  @type_drone       "drone"
   @type_local       "local"
   @type_html        "html"
   @type_json        "json"
@@ -69,6 +71,13 @@ defmodule ExCoveralls do
   """
   def analyze(stats, @type_semaphore, options) do
     Semaphore.execute(stats, options)
+  end
+
+  @doc """
+  Logic for posting from drone-ci server
+  """
+  def analyze(stats, @type_drone, options) do
+    Drone.execute(stats, options)
   end
 
   @doc """

--- a/lib/excoveralls/drone.ex
+++ b/lib/excoveralls/drone.ex
@@ -1,0 +1,66 @@
+defmodule ExCoveralls.Drone do
+  @moduledoc """
+  Handles drone-ci integration with coveralls.
+  """
+  alias ExCoveralls.Poster
+
+  def execute(stats, options) do
+    json = generate_json(stats, Enum.into(options, %{}))
+    if options[:verbose] do
+      IO.puts json
+    end
+    Poster.execute(json)
+  end
+
+  def generate_json(stats, options \\ %{})
+  def generate_json(stats, options) do
+    Jason.encode!(%{
+      repo_token: get_repo_token(),
+      service_name: "drone",
+      service_number: get_build_num(),
+      service_job_id: get_build_num(),
+      service_pull_request: get_pull_request(),
+      source_files: stats,
+      git: generate_git_info(),
+      parallel: options[:parallel]
+    })
+  end
+
+  defp generate_git_info do
+    %{head: %{
+       committer_name: get_committer(),
+       message: get_message(),
+       id: get_sha()
+      },
+      branch: get_branch()
+    }
+  end
+
+  defp get_pull_request do
+    System.get_env("DRONE_PULL_REQUEST")
+  end
+
+  defp get_message do
+    System.get_env("DRONE_COMMIT_MESSAGE")
+  end
+
+  defp get_committer do
+    System.get_env("DRONE_COMMIT_AUTHOR")
+  end
+
+  defp get_sha do
+    System.get_env("DRONE_COMMIT_SHA")
+  end
+
+  defp get_branch do
+    System.get_env("DRONE_BRANCH")
+  end
+
+  defp get_build_num do
+    System.get_env("DRONE_BUILD_NUMBER")
+  end
+
+  defp get_repo_token do
+    System.get_env("COVERALLS_REPO_TOKEN")
+  end
+end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -170,6 +170,20 @@ defmodule Mix.Tasks.Coveralls do
     end
   end
 
+  defmodule Drone do
+    @moduledoc """
+    Provides an entry point for DroneCI's script.
+    """
+
+    use Mix.Task
+
+    @preferred_cli_env :test
+
+    def run(args) do
+      Mix.Tasks.Coveralls.do_run(args, [type: "drone"])
+    end
+  end
+
   defmodule Post do
     @moduledoc """
     Provides an entry point for posting test coverage to

--- a/test/drone_test.exs
+++ b/test/drone_test.exs
@@ -1,0 +1,73 @@
+defmodule ExCoveralls.DroneTest do
+  use ExUnit.Case
+  import Mock
+  alias ExCoveralls.Drone
+
+  @content     "defmodule Test do\n  def test do\n  end\nend\n"
+  @counts      [0, 1, nil, nil]
+  @source_info [%{name: "test/fixtures/test.ex",
+                 source: @content,
+                 coverage: @counts
+               }]
+
+  setup do
+    # Capture existing values
+    orig_vars = ~w(DRONE_PULL_REQUEST DRONE_COMMIT_MESSAGE DRONE_COMMIT_AUTHOR DRONE_COMMIT_SHA DRONE_BRANCH DRONE_BUILD_NUMBER COVERALLS_REPO_TOKEN)
+    |> Enum.map(fn var -> {var, System.get_env(var)} end)
+
+    on_exit fn ->
+      # Reset env vars
+      for {k, v} <- orig_vars do
+        if v != nil do
+          System.put_env(k, v)
+        else
+          System.delete_env(k)
+        end
+      end
+    end
+
+    # No additional context
+    {:ok, []}
+  end
+
+  test_with_mock "execute", ExCoveralls.Poster, [execute: fn(_) -> "result" end] do
+    assert(Drone.execute(@source_info,[]) == "result")
+  end
+
+  test "generate json for drone" do
+    json = Drone.generate_json(@source_info)
+    assert(json =~ ~r/service_job_id/)
+    assert(json =~ ~r/service_name/)
+    assert(json =~ ~r/service_number/)
+    assert(json =~ ~r/source_files/)
+    assert(json =~ ~r/git/)
+  end
+
+  test "generate from env vars" do
+    System.put_env("DRONE_BRANCH", "branch")
+    System.put_env("DRONE_PULL_REQUEST", "39")
+    System.put_env("DRONE_COMMIT_MESSAGE", "Initial commit")
+    System.put_env("DRONE_COMMIT_AUTHOR", "username")
+    System.put_env("DRONE_COMMIT_SHA", "sha1")
+    System.put_env("DRONE_BUILD_NUMBER", "0")
+    System.put_env("COVERALLS_REPO_TOKEN", "token")
+
+    {:ok, payload} = Jason.decode(Drone.generate_json(@source_info))
+    %{"git" =>
+      %{"branch" => branch,
+        "head" => %{"committer_name" => committer_name,
+                  "id" => id}}} = payload
+    
+    assert(payload["service_pull_request"] == "39")
+    assert(branch == "branch")
+    assert(id == "sha1")
+    assert(committer_name == "username")
+    assert(payload["service_number"] == "0")
+    assert(payload["repo_token"] == "token")
+  end
+
+  test "submits as `drone`" do
+    parsed = Drone.generate_json(@source_info) |> Jason.decode!
+    assert(%{ "service_name" => "drone" } = parsed)
+  end
+end

--- a/test/excoveralls_test.exs
+++ b/test/excoveralls_test.exs
@@ -19,6 +19,11 @@ defmodule ExCoverallsTest do
     assert called ExCoveralls.Semaphore.execute(@stats,[])
   end
 
+  test_with_mock "analyze drone", ExCoveralls.Drone, [execute: fn(_,_) -> nil end] do
+    ExCoveralls.analyze(@stats, "drone", [])
+    assert called ExCoveralls.Drone.execute(@stats,[])
+  end
+
   test_with_mock "analyze local", ExCoveralls.Local, [execute: fn(_,_) -> nil end] do
     ExCoveralls.analyze(@stats, "local", [])
     assert called ExCoveralls.Local.execute(@stats,[])


### PR DESCRIPTION
Add dedicated mix task to send coveralls reports from drone CI:
~~~
mix coveralls.drone
~~~

![screen shot 2018-08-24 at 15 45 34](https://user-images.githubusercontent.com/1420693/44587982-ca03d200-a7b4-11e8-9376-5ff7bb975b01.png)

![screen shot 2018-08-24 at 16 18 58](https://user-images.githubusercontent.com/1420693/44589702-8364a680-a7b9-11e8-8006-a4dc4791819b.png)


Still investigating if drone CI exposes github account URL. For now `committer` contains only user name.

BTW, how all these attributes (committer, build nr, pr nr) are sent by travis task? I could not find it in the code?