### PR TITLE
Parallel support for separate CircleCI Workflow jobs

### DIFF
--- a/lib/excoveralls/circle.ex
+++ b/lib/excoveralls/circle.ex
@@ -17,8 +17,8 @@ defmodule ExCoveralls.Circle do
     Jason.encode!(%{
       repo_token: get_repo_token(),
       service_name: "circle-ci",
-      service_number: get_build_num(),
-      service_job_id: get_build_num(),
+      service_number: get_number(),
+      service_job_id: get_job_id(),
       service_pull_request: get_pull_request(),
       source_files: stats,
       git: generate_git_info(),
@@ -62,8 +62,16 @@ defmodule ExCoveralls.Circle do
     System.get_env("CIRCLE_BRANCH")
   end
 
-  defp get_build_num do
+  defp get_job_id do
+    # When using workflows, each job has a separate `CIRCLE_BUILD_NUM`, so this needs to be used as the Job ID and not
+    # the Job Number.
     System.get_env("CIRCLE_BUILD_NUM")
+  end
+
+  defp get_number do
+    # `CIRCLE_WORKFLOW_WORKSPACE_ID` is the same when "Rerun failed job" is done while `CIRCLE_WORKFLOW_ID` changes, so
+    # use `CIRCLE_WORKFLOW_WORKSPACE_ID` so that the results from the original and rerun are combined
+    System.get_env("CIRCLE_WORKFLOW_WORKSPACE_ID") || System.get_env("CIRCLE_BUILD_NUM")
   end
 
   defp get_repo_token do


### PR DESCRIPTION
# Changelog
## Enhancements
* `CIRCLE_WORKFLOW_WORKSPACE_ID` is the same when "Rerun failed job" is done while `CIRCLE_WORKFLOW_ID` changes, so use `CIRCLE_WORKFLOW_WORKSPACE_ID` for `service_number`, so that the results from the original and rerun are combined.  Use `CIRCLE_BUILD_NUM` for `service_number` either in or out of Workflows.

  This appears to match the usage of `service_number` and `service_job_id` in
https://github.com/lemurheavy/coveralls-ruby/commit/cf20b3a3242483b7b5bf7fbdf149008aa0a20541, which added parallel support for the older, parallel-in-1-job system to coveralls-ruby - `service_job_id` varies over the parallel things while
`service_number` must be the same across all parallel siblings.
  
  A workflow using `--parallel` and a manual `done` single with `curl` call can be seen [here](https://circleci.com/workflow-run/13ca46a5-50b5-40c4-ab09-c30fe9bbeb92) and [reported on coveralls.io](https://coveralls.io/builds/18687111)