### PR TITLE
Fix #156 - argument passing for post task

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -203,7 +203,7 @@ defmodule Mix.Tasks.Coveralls do
       aliases = [f: :filter, u: :umbrella, v: :verbose]
       {remaining, options} = Mix.Tasks.Coveralls.parse_common_options(
         args,
-        switches: switches,
+        switches: switches ++ [sha: :string, token: :string, commiter: :string, branch: :string, message: :string],
         aliases: aliases ++ [n: :name, b: :branch, c: :committer, m: :message, s: :sha, t: :token]
       )
 

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -179,7 +179,7 @@ defmodule Mix.Tasks.CoverallsTest do
       }
     ]) do
       non_standard_args = ["--no-start", "--include integration"]
-      post_args = ["-t", "token", "-s", "asdf", "--umbrella"] ++ non_standard_args
+      post_args = ["--token", "token", "-s", "asdf", "--umbrella"] ++ non_standard_args
 
       Mix.Tasks.Coveralls.Post.run(post_args)
 

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -165,6 +165,29 @@ defmodule Mix.Tasks.CoverallsTest do
     end
   end
 
+  test "non standard post arguments propagates to runner" do
+    with_mocks([
+      {
+        Runner,
+        [],
+        [run: fn(_, _) -> nil end]
+      },
+      {
+        ExCoveralls.Poster,
+        [],
+        [execute: fn(_, _) -> :ok end]
+      }
+    ]) do
+      non_standard_args = ["--no-start", "--include integration"]
+      post_args = ["-t", "token", "-s", "asdf", "--umbrella"] ++ non_standard_args
+
+      Mix.Tasks.Coveralls.Post.run(post_args)
+
+      assert(called Runner.run("test", ["--cover" | non_standard_args]))
+      assert(ExCoveralls.ConfServer.get()[:umbrella])
+    end
+  end
+
   test "extract service name by param" do
     assert Mix.Tasks.Coveralls.Post.extract_service_name([name: "local_param"]) == "local_param"
   end


### PR DESCRIPTION
This is an attempt at fixing #156 by making sure that extra arguments for the `post` task makes it down to mix.
Could probably be done nicer with some bigger changes.