### PR TITLE
GZIP the JSON for coveralls and loosen the timeout

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -2,20 +2,21 @@ defmodule ExCoveralls.Poster do
   @moduledoc """
   Post JSON to coveralls server.
   """
-  @file_name "excoveralls.post.json"
+  @file_name "excoveralls.post.json.gz"
 
   @doc """
   Create a temporarily json file and post it to server using hackney library.
   Then, remove the file after it's completed.
   """
   def execute(json, options \\ []) do
-    File.write!(@file_name, json)
+    File.write!(@file_name, json |> :zlib.gzip())
     response = send_file(@file_name, options)
     File.rm!(@file_name)
 
     case response do
       {:ok, message} ->
-        IO.puts message
+        IO.puts(message)
+
       {:error, message} ->
         raise ExCoveralls.ReportUploadError, message: message
     end
@@ -24,21 +25,30 @@ defmodule ExCoveralls.Poster do
   defp send_file(file_name, options) do
     Application.ensure_all_started(:hackney)
     endpoint = options[:endpoint] || "https://coveralls.io"
-    response = :hackney.request(:post, "#{endpoint}/api/v1/jobs", [],
-      {:multipart, [
-        {:file, file_name,
-          {"form-data", [{"name", "json_file"}, {"filename", file_name}]},
-          [{"Content-Type", "application/json"}]
-        }
-      ]}
-    )
+
+    response =
+      :hackney.request(
+        :post,
+        "#{endpoint}/api/v1/jobs",
+        [],
+        {:multipart,
+         [
+           {:file, file_name, {"form-data", [{"name", "json_file"}, {"filename", file_name}]},
+            [{"Content-Type", "gzip/json"}]}
+         ]}
+      )
+
     case response do
       {:ok, status_code, _, _} when status_code in 200..299 ->
         {:ok, "Successfully uploaded the report to '#{endpoint}'."}
 
       {:ok, status_code, _, client} ->
         {:ok, body} = :hackney.body(client)
-        {:error, "Failed to upload the report to '#{endpoint}' (reason: status_code = #{status_code}, body = #{body})."}
+
+        {:error,
+         "Failed to upload the report to '#{endpoint}' (reason: status_code = #{status_code}, body = #{
+           body
+         })."}
 
       {:error, reason} ->
         {:error, "Failed to upload the report to '#{endpoint}' (reason: #{reason})."}

--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -35,7 +35,8 @@ defmodule ExCoveralls.Poster do
          [
            {:file, file_name, {"form-data", [{"name", "json_file"}, {"filename", file_name}]},
             [{"Content-Type", "gzip/json"}]}
-         ]}
+         ]},
+        [{:recv_timeout, 10_000}]
       )
 
     case response do

--- a/test/poster_test.exs
+++ b/test/poster_test.exs
@@ -3,13 +3,13 @@ defmodule PosterTest do
   import Mock
   import ExUnit.CaptureIO
 
-  test_with_mock "post json", :hackney, [request: fn(_, _, _, _) -> {:ok, 200, "", ""} end] do
+  test_with_mock "post json", :hackney, [request: fn(_, _, _, _, _) -> {:ok, 200, "", ""} end] do
     assert capture_io(fn ->
       ExCoveralls.Poster.execute("json")
     end) =~ ~r/Successfully uploaded/
   end
 
-  test_with_mock "post json fails", :hackney, [request: fn(_, _, _, _) -> {:error, "failed"} end] do
+  test_with_mock "post json fails", :hackney, [request: fn(_, _, _, _, _) -> {:error, "failed"} end] do
     assert_raise ExCoveralls.ReportUploadError, fn ->
       ExCoveralls.Poster.execute("json")
     end


### PR DESCRIPTION
Our JSON payload for coveralls seems to be quite substantial and we're suffering from timeouts which block our CI workflow. This PR gzips the payload before sending as the coveralls API supports this and loosens the timeout from 5sec to 10sec.