### PR TITLE
Do not fail due to timeout from poster

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -51,6 +51,9 @@ defmodule ExCoveralls.Poster do
            body
          })."}
 
+      {:error, :timeout} ->
+        {:ok, "Unable to upload the report to '#{endpoint}' due to a timeout. Not failing the build."}
+
       {:error, reason} ->
         {:error, "Failed to upload the report to '#{endpoint}' (reason: #{reason})."}
     end

--- a/test/poster_test.exs
+++ b/test/poster_test.exs
@@ -14,4 +14,10 @@ defmodule PosterTest do
       ExCoveralls.Poster.execute("json")
     end
   end
+
+  test_with_mock "post json timeout", :hackney, [request: fn(_, _, _, _, _) -> {:error, :timeout} end] do
+    assert capture_io(fn ->
+      assert ExCoveralls.Poster.execute("json") == :ok
+    end) =~ ~r/timeout/
+  end
 end


### PR DESCRIPTION
Small fix for #112 
Might make more sense with an option to control this, but I figured this should be a good default for most cases.