### PR TITLE
fix spelling on doc for ExCoveralls.Stats.report/1

### DIFF
--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -22,7 +22,7 @@ defmodule ExCoveralls.Stats do
   end
 
   @doc """
-  Report the statistical information for he specified module.
+  Report the statistical information for the specified module.
   """
   def report(modules) do
     calculate_stats(modules)


### PR DESCRIPTION
Just  a minor spelling fix I came across while looking at source code.