### PR TITLE
Fix UnicodeConversionError and faster count_line

### DIFF
--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -103,7 +103,7 @@ defmodule ExCoveralls.Stats do
   end
 
   defp count_lines(string) do
-    1 + Enum.count(string_to_charlist(string), fn(x) -> x == ?\n end)
+    1 + (Regex.scan(~r/\n/i, string) |> length)
   end
 
   @doc """


### PR DESCRIPTION
When having special character in a file, we had a crash : 
```
(UnicodeConversionError) invalid encoding starting at <<161, 41, 32, 45, 62, 32, 36, 105, 59, 10, 105, 115, 111, 95, 116, 111, 95, 97, 115, 99, 105, 105, 40, 36, 162, 41, 32, 45, 62, 32, 36, 99, 59, 10, 105, 115, 111, 95, 116, 111, 95, 97, 115, 99, 105, 105, 40, 36, 163, 41, ...>>
    (elixir) lib/string.ex:2154: String.to_charlist/1
    lib/excoveralls/stats.ex:106: ExCoveralls.Stats.count_lines/1
    lib/excoveralls/stats.ex:64: anonymous fn/2 in ExCoveralls.Stats.generate_coverage/1
    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
    lib/excoveralls/stats.ex:29: ExCoveralls.Stats.report/1
    lib/excoveralls.ex:39: ExCoveralls.execute/2
    (mix) lib/mix/tasks/test.ex:390: Mix.Tasks.Test.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/task.ex:365: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:292: Mix.Task.run/2
    lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
    (elixir) lib/code.ex:767: Code.require_file/2
```

The method of lines counting is also faster than the previous one.