### PR TITLE
Display path to HTML report after generation

### DIFF
--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -38,6 +38,7 @@ defmodule ExCoveralls.Html do
       File.mkdir!(file_path)
     end
     File.write!(Path.expand(@file_name, file_path), content)
+    IO.puts "Saved to: #{file_path}"
   end
 
 end


### PR DESCRIPTION
I had an issue the other day where I could not remember where a generated report is being saved to. So I figured it would be useful to print the file location after successful generation.

