### PR TITLE
Clean compiling warning

### DIFF
--- a/lib/excoveralls/ignore.ex
+++ b/lib/excoveralls/ignore.ex
@@ -44,7 +44,7 @@ defmodule ExCoveralls.Ignore do
     case Regex.run(~r/coveralls-ignore-(start|stop)/, line, capture: :all_but_first) do
       ["start"] -> true
       ["stop"] -> false
-      sth -> ignore
+      _sth -> ignore
     end
   end
 

--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -221,9 +221,4 @@ defmodule ExCoveralls.Stats do
     end
   end
 
-  if Version.compare(System.version, "1.3.0") == :lt do
-    defp string_to_charlist(string), do: String.to_char_list(string)
-  else
-    defp string_to_charlist(string), do: String.to_charlist(string)
-  end
 end


### PR DESCRIPTION
For 0.11.1 version, we will see these compiling warning:
```
==> excoveralls
Compiling 24 files (.ex)
warning: variable "sth" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/excoveralls/ignore.ex:47

warning: function string_to_charlist/1 is unused
  lib/excoveralls/stats.ex:227
```
The unused `string_to_charlist/1` change was made from this commit https://github.com/parroty/excoveralls/commit/a059e4220ef08b097a238783d19f0f7871ed9c75

This PR is to clean these warning, please review.