### PR TITLE
Remove unnecessary quoted keyword from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ def project do
     elixir: "~> 1.0.0",
     deps: deps(Mix.env),
     test_coverage: [tool: ExCoveralls],
-    preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
+    preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
     # if you want to use espec,
     # test_coverage: [tool: ExCoveralls, test_task: "espec"]
   ]


### PR DESCRIPTION
Mix gives a warning for quoting keywords when they are not required. Fixing this in the example should prevent downstream project from getting this warning when compiling.