### PR TITLE
Update path creation/handling for artifacts

### DIFF
--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -40,7 +40,7 @@ defmodule ExCoveralls.Html do
   defp write_file(content, output_dir) do
     file_path = output_dir(output_dir)
     unless File.exists?(file_path) do
-      File.mkdir!(file_path)
+      File.mkdir_p!(file_path)
     end
 
     File.write!(Path.expand(@file_name, file_path), content)

--- a/lib/excoveralls/json.ex
+++ b/lib/excoveralls/json.ex
@@ -36,7 +36,7 @@ defmodule ExCoveralls.Json do
   defp write_file(content, output_dir) do
     file_path = output_dir(output_dir)
     unless File.exists?(file_path) do
-      File.mkdir!(file_path)
+      File.mkdir_p!(file_path)
     end
     File.write!(Path.expand(@file_name, file_path), content)
   end


### PR DESCRIPTION
When attempting to run `mix coveralls -o public/cover` to generate coverage docs for usage in GitLab pages I get the following error: `** (File.Error) could not make directory "./public/cover": no such file or directory`

By simply adding the -p options to `mkdir` this ceases to be a problem. Hence I switched both `File.mkdir!/1` calls to `File.mkdir_p!/1`