### PR TITLE
remove UndefinedFunctionError requirement for logging missing source error

### DIFF
--- a/lib/excoveralls/cover.ex
+++ b/lib/excoveralls/cover.ex
@@ -39,7 +39,7 @@ defmodule ExCoveralls.Cover do
         end
     end
   rescue
-    _e in UndefinedFunctionError ->
+    _e ->
       log_missing_source(module)
       false
   end


### PR DESCRIPTION
log error instead of crashes like this

```
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1    
    
    The following arguments were given to IO.chardata_to_string/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 2 out of 2):
    
        def chardata_to_string(+string+) when -is_binary(string)-
        def chardata_to_string(+list+) when -is_list(list)-
    
    (elixir) lib/io.ex:557: IO.chardata_to_string/1
    (elixir) lib/file.ex:214: File.exists?/2
    (excoveralls) lib/excoveralls/cover.ex:43: ExCoveralls.Cover.has_compile_info?/1
    (elixir) lib/enum.ex:2942: Enum.filter_list/2
    (elixir) lib/enum.ex:2943: Enum.filter_list/2
    (excoveralls) lib/excoveralls.ex:39: ExCoveralls.execute/2
    (mix) lib/mix/tasks/test.ex:446: Mix.Tasks.Test.do_run/3
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (excoveralls) lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
    (elixir) lib/code.ex:813: Code.require_file/2
```