### PR TITLE
Better SHA GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Usage: mix coveralls.travis [--pro]
   Used to post coverage from Travis CI server.
 
 Usage: mix coveralls.github
-  Used to post coverage from [GitHub Actions](https://github.com/features/actions).
+  Used to post coverage from GitHub Actions
 
 Usage: mix coveralls.post <Options>
   Used to post coverage from local server using token.

--- a/lib/excoveralls/github.ex
+++ b/lib/excoveralls/github.ex
@@ -18,7 +18,7 @@ defmodule ExCoveralls.Github do
 
   def generate_json(stats, options) do
     %{
-      repo_token: get_env("GITHUB_TOKEN"),
+      repo_token: System.get_env("GITHUB_TOKEN"),
       service_name: "github",
       source_files: stats,
       parallel: options[:parallel],
@@ -28,14 +28,8 @@ defmodule ExCoveralls.Github do
     |> Jason.encode!()
   end
 
-  defp get_env(env) do
-    env
-    |> System.get_env()
-  end
-
   defp job_data() do
-    get_env("GITHUB_EVENT_NAME")
-    |> case do
+    case System.get_env("GITHUB_EVENT_NAME") do
       "pull_request" ->
         pr_sha =
           get_sha("pull_request")
@@ -57,25 +51,22 @@ defmodule ExCoveralls.Github do
 
   defp get_pr_id do
     event_info()
-    |> Map.get("number")
+    |> get_in(["number"])
     |> Integer.to_string()
   end
 
   defp get_committer_name do
     event_info()
-    |> Map.get("sender")
-    |> Map.get("login")
+    |> get_in(["sender", "login"])
   end
 
   defp get_sha("pull_request") do
     event_info()
-    |> Map.get("pull_request")
-    |> Map.get("head")
-    |> Map.get("sha")
+    |> get_in(["pull_request", "head", "sha"])
   end
 
   defp get_sha(_) do
-    get_env("GITHUB_SHA")
+    System.get_env("GITHUB_SHA")
   end
 
   defp get_message("pull_request") do
@@ -89,13 +80,13 @@ defmodule ExCoveralls.Github do
   end
 
   defp event_info do
-    get_env("GITHUB_EVENT_PATH")
+    System.get_env("GITHUB_EVENT_PATH")
     |> File.read!()
     |> Jason.decode!()
   end
 
   defp git_info do
-    event = get_env("GITHUB_EVENT_NAME")
+    event = System.get_env("GITHUB_EVENT_NAME")
 
     %{
       head: %{
@@ -113,6 +104,6 @@ defmodule ExCoveralls.Github do
   end
 
   defp get_branch do
-    get_env("GITHUB_REF")
+    System.get_env("GITHUB_REF")
   end
 end

--- a/lib/excoveralls/github.ex
+++ b/lib/excoveralls/github.ex
@@ -25,31 +25,40 @@ defmodule ExCoveralls.Github do
       git: git_info()
     }
     |> Map.merge(job_data())
-    |> Jason.encode!
+    |> Jason.encode!()
   end
 
   defp get_env(env) do
     env
-    |> System.get_env
+    |> System.get_env()
   end
 
   defp job_data() do
     get_env("GITHUB_EVENT_NAME")
     |> case do
       "pull_request" ->
+        pr_sha =
+          get_sha("pull_request")
+          |> sha_resume()
+
         %{
           service_pull_request: get_pr_id(),
-          service_job_id: "#{get_sha("pull_request")}-PR-#{get_pr_id()}",
+          service_job_id: "PR-#{get_pr_id()}-#{pr_sha}"
         }
+
       event ->
-        %{service_job_id: get_sha(event)}
+        sha =
+          get_sha(event)
+          |> sha_resume()
+
+        %{service_job_id: sha}
     end
   end
 
   defp get_pr_id do
     event_info()
     |> Map.get("number")
-    |> Integer.to_string
+    |> Integer.to_string()
   end
 
   defp get_committer_name do
@@ -87,6 +96,7 @@ defmodule ExCoveralls.Github do
 
   defp git_info do
     event = get_env("GITHUB_EVENT_NAME")
+
     %{
       head: %{
         id: get_sha(event),
@@ -95,6 +105,11 @@ defmodule ExCoveralls.Github do
       },
       branch: get_branch()
     }
+  end
+
+  defp sha_resume(sha) do
+    sha
+    |> String.slice(0..6)
   end
 
   defp get_branch do

--- a/test/github_test.exs
+++ b/test/github_test.exs
@@ -33,9 +33,8 @@ defmodule ExCoveralls.GithubTest do
   test "generate from env vars" do
     {:ok, payload} = Jason.decode(Github.generate_json(@source_info))
 
-
     assert(payload["repo_token"] == "token")
-    assert(payload["service_job_id"] == "7c90516a3ac9f43ab6cf46ec5668b4430a3af103-PR-206")
+    assert(payload["service_job_id"] == "PR-206-7c90516")
     assert(payload["service_name"] == "github")
     assert(payload["service_pull_request"] == "206")
   end

--- a/test/github_test.exs
+++ b/test/github_test.exs
@@ -6,13 +6,30 @@ defmodule ExCoveralls.GithubTest do
   @content "defmodule Test do\n  def test do\n  end\nend\n"
   @counts [0, 1, nil, nil]
   @source_info [%{name: "test/fixtures/test.ex", source: @content, coverage: @counts}]
+
   setup do
-    # No additional context
+    # Capture existing values
+    orig_vars =
+      ~w(GITHUB_EVENT_PATH GITHUB_SHA GITHUB_EVENT_NAME GITHUB_REF GITHUB_TOKEN)
+      |> Enum.map(fn var -> {var, System.get_env(var)} end)
+
+    on_exit(fn ->
+      # Reset env vars
+      for {k, v} <- orig_vars do
+        if v != nil do
+          System.put_env(k, v)
+        else
+          System.delete_env(k)
+        end
+      end
+    end)
+
     System.put_env("GITHUB_EVENT_PATH", "test/fixtures/github_event.json")
     System.put_env("GITHUB_SHA", "sha1")
     System.put_env("GITHUB_EVENT_NAME", "pull_request")
     System.put_env("GITHUB_REF", "branch")
     System.put_env("GITHUB_TOKEN", "token")
+    # No additional context
     {:ok, []}
   end
 


### PR DESCRIPTION
This change the default job id for a short SHA of the last commit. 

And solve the internal tests environment variables issue, but the test of excoveralls it self on github actions will fail because the capture_io on the test with assertions on exit codes are not supported in github actions in this moment.

We have to talk about that in the issue #211 .