### PR TITLE
Fix build failure due to `:connect_timeout` from poster

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -51,7 +51,7 @@ defmodule ExCoveralls.Poster do
            body
          })."}
 
-      {:error, :timeout} ->
+      {:error, reason}  when reason in [:timeout, :connect_timeout] ->
         {:ok, "Unable to upload the report to '#{endpoint}' due to a timeout. Not failing the build."}
 
       {:error, reason} ->

--- a/test/poster_test.exs
+++ b/test/poster_test.exs
@@ -15,7 +15,8 @@ defmodule PosterTest do
     end
   end
 
-  test_with_mock "post json timeout", :hackney, [request: fn(_, _, _, _, _) -> {:error, :timeout} end] do
+  test_with_mock "post json timeout", :hackney, [request: fn(_, _, _, _, _) -> {:error, :timeout} end,
+                                                 request: fn(_, _, _, _, _) -> {:error, :connect_timeout} end] do
     assert capture_io(fn ->
       assert ExCoveralls.Poster.execute("json") == :ok
     end) =~ ~r/timeout/


### PR DESCRIPTION
Updated the poster to accept either `:timeout` or `:connect_timeout` as a timeout issue (and therefore don't fail the build) and its corresponding test to also mock that case.