### PR TITLE
Fix error reason message

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -55,7 +55,7 @@ defmodule ExCoveralls.Poster do
         {:ok, "Unable to upload the report to '#{endpoint}' due to a timeout. Not failing the build."}
 
       {:error, reason} ->
-        {:error, "Failed to upload the report to '#{endpoint}' (reason: #{reason})."}
+        {:error, "Failed to upload the report to '#{endpoint}' (reason: #{inspect(reason)})."}
     end
   end
 end


### PR DESCRIPTION
This fixes an exception you'd get if the error reason is something more
complicated than an atom or string. For example:

```
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:options, {:sslv3, {:versions, [:"tlsv1.2", :"tlsv1.1", :tlsv1, :sslv3]}}} of type Tuple. This protocol is implemented for the following type(s): Time, NaiveDateTime, List, Version, Atom, URI, DateTime, Integer, Date, BitString, Float, Version.Requirement
    (elixir 1.10.3) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.10.3) lib/string/chars.ex:22: String.Chars.to_string/1
    lib/excoveralls/poster.ex:58: ExCoveralls.Poster.send_file/2
    lib/excoveralls/poster.ex:13: ExCoveralls.Poster.execute/2
    (mix 1.10.3) lib/mix/tasks/test.ex:484: Mix.Tasks.Test.do_run/3
    (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
    lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
    (mix 1.10.3) lib/mix/cli.ex:82: Mix.CLI.run_task/2
    (elixir 1.10.3) lib/code.ex:926: Code.require_file/2
```