### PR TITLE
OTP 23: Force SSL options so that sslv3 isn't used

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -36,7 +36,7 @@ defmodule ExCoveralls.Poster do
            {:file, file_name, {"form-data", [{"name", "json_file"}, {"filename", file_name}]},
             [{"Content-Type", "gzip/json"}]}
          ]},
-        [{:recv_timeout, 10_000}]
+        [{:recv_timeout, 10_000}, {:ssl_options, [{:versions, [:"tlsv1.2", :"tlsv1.1", :tlsv1]}]}]
       )
 
     case response do


### PR DESCRIPTION
This fixes the following error when using OTP 23:

```
 ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:options, {:sslv3, {:versions, [:"tlsv1.2", :
        (elixir 1.10.3) lib/string/chars.ex:3: String.Chars.impl_for!/1
        (elixir 1.10.3) lib/string/chars.ex:22: String.Chars.to_string/1
        lib/excoveralls/poster.ex:58: ExCoveralls.Poster.send_file/2
        lib/excoveralls/poster.ex:13: ExCoveralls.Poster.execute/2
        (mix 1.10.3) lib/mix/tasks/test.ex:484: Mix.Tasks.Test.do_run/3
        (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
        lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
        (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
        (mix 1.10.3) lib/mix/cli.ex:82: Mix.CLI.run_task/2
        (elixir 1.10.3) lib/code.ex:926: Code.require_file/2
```

The error is due to hackney adding sslv3 to the ssl_options when they
aren't specified and OTP 23 removing support for sslv3. An update to
hackney that supports OTP 23 should fix this issue as well, but this
patch will fix it until then.