### PR TITLE
Fixing mocked modules coverage handling

### DIFF
--- a/lib/excoveralls/cover.ex
+++ b/lib/excoveralls/cover.ex
@@ -27,16 +27,14 @@ defmodule ExCoveralls.Cover do
   end
 
   def has_compile_info?(module) do
-    case module.module_info(:compile) do
-      nil -> false
-      info ->
-        path = Keyword.get(info, :source)
-        if File.exists?(path) do
-          true
-        else
-          log_missing_source(module)
-          false
-        end
+    with info when not is_nil(info) <- module.module_info(:compile),
+         path when not is_nil(path) <- Keyword.get(info, :source),
+         true <- File.exists?(path) do
+      true
+    else
+      _e ->
+        log_missing_source(module)
+        false
     end
   rescue
     _e ->

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -32,6 +32,14 @@ defmodule CoverTest do
     end) =~ "[warning] skipping the module 'Elixir.TestMissing' because source information for the module is not available."
   end
 
+  test "has_compile_info?/1 with a mocked module raises warning and returns false" do
+    :ok = :meck.new(MockedModule, [:non_strict])
+
+    assert capture_io(:stderr, fn ->
+      refute Cover.has_compile_info?(MockedModule)
+    end) =~ "[warning] skipping the module 'Elixir.MockedModule' because source information for the module is not available."
+  end
+
   test "has_compile_info?/1 with existing source returns true" do
     assert Cover.has_compile_info?(TestMissing)
   end


### PR DESCRIPTION

Currently, elixir modules mocked using the [meck](https://github.com/eproxus/meck) library may leave a trace in the modules list that `excoveralls` tries to cover which won't have a `source` key. As mocks, It is expected that those modules wouldn't have a corresponding source file, but `excoveralls` currently doesn't handle this case. This pull request addresses this issue by improving the bypass logic of modules without a source file.

## Examples of the return of [module_info/1](https://erlang.org/doc/reference_manual/modules.html#module_info-1)

### Unmocked, compiled and executed module

```elixir
[
  version: '7.4',
  options: [:no_spawn_compiler_process, :from_core, :no_auto_import],
  source: '/Users/diogo.martins/dev/excoveralls/test_missing.ex'
]
```

### Mocked module

```elixir
[version: '7.4', options: []]
```



The mocked module scenario starts breaking when whe assume that every module has a `:source` at `Keyword.get(info, :source)`. It returns `nil` and `has_compile_info?/1` tries to call `File.exists?/1` with `nil`, resulting in the following stacktrace:

```
Randomized with seed 319344
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1    
    
    The following arguments were given to IO.chardata_to_string/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 2 out of 2):
    
        def chardata_to_string(+string+) when -is_binary(string)-
        def chardata_to_string(+list+) when -is_list(list)-
    
    (elixir) lib/io.ex:461: IO.chardata_to_string/1
    (elixir) lib/file.ex:214: File.exists?/2
    lib/excoveralls/cover.ex:34: ExCoveralls.Cover.has_compile_info?/1
    (elixir) lib/enum.ex:2934: Enum.filter_list/2
    (elixir) lib/enum.ex:2935: Enum.filter_list/2
    lib/excoveralls.ex:39: ExCoveralls.execute/2
    (mix) lib/mix/tasks/test.ex:390: Mix.Tasks.Test.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/project.ex:348: Mix.Project.in_project/4
    (elixir) lib/file.ex:1506: File.cd!/2
    (mix) lib/mix/task.ex:431: anonymous fn/4 in Mix.Task.recur/1
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix) lib/mix/task.ex:430: Mix.Task.recur/1
    (mix) lib/mix/project_stack.ex:208: Mix.ProjectStack.recur/1
    lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```
