### PR TITLE
Remove `text-align: right` so filenames are easier to scan

### DIFF
--- a/lib/templates/html/htmlcov/_style.html.eex
+++ b/lib/templates/html/htmlcov/_style.html.eex
@@ -118,7 +118,6 @@ footer span {
   margin: 0;
   height: 100%;
   padding: 15px 0;
-  text-align: right;
   border-left: 1px solid #eee;
   -moz-box-shadow: 0 0 2px #888
      , inset 5px 0 20px rgba(0,0,0,.5)


### PR DESCRIPTION
When working on a large project with many deeply-nested files, scanning the list of files for a particular one is difficult because of the right-alignment. This change makes the file paths line up so you can quickly tell when you're looking at a different folder. The coverage percentage remains right-aligned, so that is still easy to scan.