### PR TITLE
Fix issue with CircleCI parallel workflows not picking up separate builds

### DIFF
--- a/lib/excoveralls/circle.ex
+++ b/lib/excoveralls/circle.ex
@@ -64,7 +64,8 @@ defmodule ExCoveralls.Circle do
 
   defp get_job_id do
     # When using workflows, each job has a separate `CIRCLE_BUILD_NUM`, so this needs to be used as the Job ID and not
-    # the Job Number.
+    # the Job Number. If the job is configured with `parallelism` greater than one, then the `CIRCLE_NODE_INDEX` is
+    # used to differentiate between separate containers running the same job.
     "#{System.get_env("CIRCLE_BUILD_NUM")}-#{System.get_env("CIRCLE_NODE_INDEX")}"
   end
 

--- a/lib/excoveralls/circle.ex
+++ b/lib/excoveralls/circle.ex
@@ -65,7 +65,7 @@ defmodule ExCoveralls.Circle do
   defp get_job_id do
     # When using workflows, each job has a separate `CIRCLE_BUILD_NUM`, so this needs to be used as the Job ID and not
     # the Job Number.
-    System.get_env("CIRCLE_BUILD_NUM")
+    "#{System.get_env("CIRCLE_BUILD_NUM")}-#{System.get_env("CIRCLE_NODE_INDEX")}"
   end
 
   defp get_number do


### PR DESCRIPTION
In our experience using `mix coveralls.circle --parallel --umbrella` the parallel jobs are reported using a duplicate `service_job_id`. I've added the `CIRCLE_NODE_INDEX` as suggested on the main Coveralls repository at https://github.com/lemurheavy/coveralls-public/issues/1341#issuecomment-611676566.

I am not sure if this is backwards incompatible for older CircleCI users, might be good for them to test this and chime in as well.