### PR TITLE
Make :hackney an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ end
 defp deps do
   [
     {:excoveralls, "~> 0.10", only: :test},
+    {:hackney, "~> 1.16", only: :test} # only required if posting to the coveralls.io service
   ]
 end
 ```

--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -22,6 +22,7 @@ defmodule ExCoveralls.Poster do
     end
   end
 
+if Code.ensure_loaded?(:hackney) do
   defp send_file(file_name, options) do
     Application.ensure_all_started(:hackney)
     endpoint = options[:endpoint] || "https://coveralls.io"
@@ -62,4 +63,18 @@ defmodule ExCoveralls.Poster do
         {:error, "Failed to upload the report to '#{endpoint}' (reason: #{inspect(reason)})."}
     end
   end
+else
+  defp send_file(_, _) do
+    raise """
+    missing :hackney dependency
+
+    ExCoveralls requires :hackney to post to the coveralls.io service.
+
+    Please add :hackney to your mix.exs :deps list and run:
+
+        mix deps.get
+        mix deps.clean --build excoveralls
+    """
+  end
+end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ExCoveralls.Mixfile do
   def deps do
     [
       {:jason, "~> 1.0"},
-      {:hackney, "~> 1.16"},
+      {:hackney, "~> 1.16", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:meck, "~> 0.8", only: :test},
       {:mock, "~> 0.3.6", only: :test},


### PR DESCRIPTION
This allows those who don't need to post to the coveralls.io service to reduce their dependencies. If they do try to run a Mix task that posts to coveralls.io, they are instructed to install `:hackney` and recompile ExCoveralls.