### PR TITLE
Elixir 1.11: :eex and :tools should be listed in :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExCoveralls.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    []
+    [extra_applications: [:eex, :tools]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
Warnings were:
```
warning: EEx.eval_file/2 defined in application :eex is used by the current application but the current application does not directly depend on :eex. To fix this, you must do one of:

  1. If :eex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :eex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :eex, you may optionally skip this warning by adding [xref: [exclude: EEx] to your "def project" in mix.exs

Found at 2 locations:
  lib/excoveralls/html/view.ex:27: ExCoveralls.Html.View.render/1
  lib/excoveralls/html/view.ex:31: ExCoveralls.Html.View.partial/2
```

and

```
warning: :cover.analyse/3 defined in application :tools is used by the current application but the current application does not directly depend on :tools. To fix this, you must do one of:

  1. If :tools is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :tools is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :tools, you may optionally skip this warning by adding [xref: [exclude: :cover] to your "def project" in mix.exs

  lib/excoveralls/cover.ex:47: ExCoveralls.Cover.analyze/1
```