### PR TITLE
Add a task to upload coverage from gitlab

### DIFF
--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -9,6 +9,7 @@ defmodule ExCoveralls do
   alias ExCoveralls.StatServer
   alias ExCoveralls.Travis
   alias ExCoveralls.Github
+  alias ExCoveralls.Gitlab
   alias ExCoveralls.Circle
   alias ExCoveralls.Semaphore
   alias ExCoveralls.Drone
@@ -20,6 +21,7 @@ defmodule ExCoveralls do
 
   @type_travis      "travis"
   @type_github      "github"
+  @type_gitlab      "gitlab"
   @type_circle      "circle"
   @type_semaphore   "semaphore"
   @type_drone       "drone"
@@ -67,6 +69,10 @@ defmodule ExCoveralls do
 
   def analyze(stats, @type_github, options) do
     Github.execute(stats, options)
+  end
+
+  def analyze(stats, @type_gitlab, options) do
+    Gitlab.execute(stats, options)
   end
 
   def analyze(stats, @type_circle, options) do

--- a/lib/excoveralls/gitlab.ex
+++ b/lib/excoveralls/gitlab.ex
@@ -1,0 +1,77 @@
+defmodule ExCoveralls.Gitlab do
+  @moduledoc """
+  Handles gitlab-ci integration with coveralls.
+  """
+  alias ExCoveralls.Poster
+
+  def execute(stats, options) do
+    json = generate_json(stats, Enum.into(options, %{}))
+
+    if options[:verbose] do
+      IO.puts(json)
+    end
+
+    Poster.execute(json)
+  end
+
+  def generate_json(stats, options \\ %{})
+
+  def generate_json(stats, options) do
+    Jason.encode!(%{
+      repo_token: get_repo_token(),
+      service_name: "gitlab-ci",
+      service_number: get_number(),
+      service_job_id: get_job_id(),
+      service_pull_request: get_pull_request(),
+      source_files: stats,
+      git: generate_git_info(),
+      parallel: options[:parallel]
+    })
+  end
+
+  defp generate_git_info do
+    %{
+      head: %{
+        committer_name: get_committer(),
+        message: get_message(),
+        id: get_sha()
+      },
+      branch: get_branch()
+    }
+  end
+
+  def get_pull_request() do
+    System.get_env("CI_MERGE_REQUEST_ID") || System.get_env("CI_EXTERNAL_PULL_REQUEST_IID")
+  end
+
+  defp get_message do
+    System.get_env("CI_COMMIT_TITLE") || "[no commit message]"
+  end
+
+  defp get_committer do
+    case System.cmd("git", ["log", "-1", "--format=%an"]) do
+      {committer, _} -> String.trim(committer)
+      _ -> "[no committer name]"
+    end
+  end
+
+  defp get_sha do
+    System.get_env("CI_COMMIT_SHA")
+  end
+
+  defp get_branch do
+    System.get_env("CI_COMMIT_BRANCH")
+  end
+
+  defp get_job_id do
+    "#{System.get_env("CI_JOB_ID")}-#{System.get_env("CI_NODE_INDEX")}"
+  end
+
+  defp get_number do
+    System.get_env("CI_PIPELINE_ID")
+  end
+
+  defp get_repo_token do
+    System.get_env("COVERALLS_REPO_TOKEN")
+  end
+end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -175,6 +175,19 @@ defmodule Mix.Tasks.Coveralls do
     end
   end
 
+  defmodule Gitlab do
+    @moduledoc """
+    Provides an entry point for gitlab's script.
+    """
+    use Mix.Task
+
+    @preferred_cli_env :test
+
+    def run(args) do
+      Mix.Tasks.Coveralls.do_run(args, type: "gitlab")
+    end
+  end
+
   defmodule Circle do
     @moduledoc """
     Provides an entry point for CircleCI's script.

--- a/test/excoveralls_test.exs
+++ b/test/excoveralls_test.exs
@@ -19,6 +19,11 @@ defmodule ExCoverallsTest do
     assert called ExCoveralls.Github.execute(@stats,[])
   end
 
+  test_with_mock "analyze gitlab", ExCoveralls.Gitlab, execute: fn _, _ -> nil end do
+    ExCoveralls.analyze(@stats, "gitlab", [])
+    assert called(ExCoveralls.Gitlab.execute(@stats, []))
+  end
+
   test_with_mock "analyze semaphore", ExCoveralls.Semaphore, [execute: fn(_,_) -> nil end] do
     ExCoveralls.analyze(@stats, "semaphore", [])
     assert called ExCoveralls.Semaphore.execute(@stats,[])

--- a/test/gitlab_test.exs
+++ b/test/gitlab_test.exs
@@ -1,0 +1,68 @@
+defmodule ExCoveralls.GitlabTest do
+  use ExUnit.Case
+  import Mock
+  alias ExCoveralls.Gitlab
+
+  @content "defmodule Test do\n  def test do\n  end\nend\n"
+  @counts [0, 1, nil, nil]
+  @source_info [%{name: "test/fixtures/test.ex", source: @content, coverage: @counts}]
+
+  setup do
+    # Capture existing values
+    orig_vars =
+      ~w(CI_MERGE_REQUEST_ID CI_EXTERNAL_PULL_REQUEST_IID CI_COMMIT_TITLE CI_COMMIT_SHA CI_COMMIT_BRANCH CI_JOB_ID CI_NODE_INDEX CI_PIPELINE_ID COVERALLS_REPO_TOKEN)
+      |> Enum.map(fn var -> {var, System.get_env(var)} end)
+
+    on_exit(fn ->
+      # Reset env vars
+      for {k, v} <- orig_vars do
+        if v != nil do
+          System.put_env(k, v)
+        else
+          System.delete_env(k)
+        end
+      end
+    end)
+
+    # No additional context
+    {:ok, []}
+  end
+
+  test_with_mock "execute", ExCoveralls.Poster, execute: fn _ -> "result" end do
+    assert(Gitlab.execute(@source_info, []) == "result")
+  end
+
+  test "generate json for gitlab" do
+    json = Gitlab.generate_json(@source_info)
+    assert(json =~ ~r/service_job_id/)
+    assert(json =~ ~r/service_name/)
+    assert(json =~ ~r/service_number/)
+    assert(json =~ ~r/source_files/)
+    assert(json =~ ~r/git/)
+  end
+
+  test "submits as `gitlab-ci` by default" do
+    parsed = Gitlab.generate_json(@source_info) |> Jason.decode!()
+    assert(%{"service_name" => "gitlab-ci"} = parsed)
+  end
+
+  test "generate from env vars" do
+    System.put_env("CI_EXTERNAL_PULL_REQUEST_IID", "39")
+    System.put_env("CI_COMMIT_TITLE", "This is the title")
+    System.put_env("CI_COMMIT_SHA", "sha1")
+    System.put_env("CI_COMMIT_BRANCH", "branch")
+    System.put_env("CI_PIPELINE_ID", "0")
+    System.put_env("COVERALLS_REPO_TOKEN", "token")
+
+    {:ok, payload} = Jason.decode(Gitlab.generate_json(@source_info))
+
+    %{"git" => %{"branch" => branch, "head" => %{"message" => message, "id" => id}}} = payload
+
+    assert payload["service_pull_request"] == "39"
+    assert branch == "branch"
+    assert id == "sha1"
+    assert message == "This is the title"
+    assert payload["service_number"] == "0"
+    assert payload["repo_token"] == "token"
+  end
+end

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -127,6 +127,12 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get == [type: "github", args: []])
   end
 
+  test_with_mock "gitlab", Runner, run: fn _, _ -> nil end do
+    Mix.Tasks.Coveralls.Gitlab.run([])
+    assert(called(Runner.run("test", ["--cover"])))
+    assert(ExCoveralls.ConfServer.get() == [type: "gitlab", args: []])
+  end
+
   test_with_mock "post with env vars", Runner, [run: fn(_, _) -> nil end] do
     org_token = System.get_env("COVERALLS_REPO_TOKEN") || ""
     org_name  = System.get_env("COVERALLS_SERVICE_NAME") || ""


### PR DESCRIPTION
Hi there, 
I see the example uses the native coverage of GitLab.
I would like to use coveralls though because of the parallel feature.
What do you think? Would it make sense to add that?

Cheers