### PR TITLE
Add options to post

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ Usage: mix coveralls.post <Options>
     -c (--committer)    Committer name ('COMMITTER' column at coveralls.io page)
     -m (--message)      Commit message ('COMMIT' column at coveralls.io page)
     -s (--sha)          Commit SHA (required when not using Travis)
+    --build             Service number ('BUILDS' column at coveralls.io page)
+    --parallel          coveralls.io 'parallel' option (See coveralls.io API Reference)
+    --subdir            Git repo sub directory: This will be added to the the front of file path, use if your covered
+                        file paths reside within a subfolder of the git repo. Example: If your source file path is
+                        "test.rb", and your git repo root is one directory up making the file's relative path
+                        "src/lib/test.rb", then the sub directory should be: "src/lib" (from coveralls.io)
+    --rootdir           This will be stripped from the file path in order to resolve the relative path of this repo's
+                        files. It should be the path to your git repo's root on your CI build environment. This is not
+                        needed if your source file path is already relative. It's used to pull the source file from the
+                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.rb",
+                        and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
+                        coveralls.io)
 ```
 
 ### [mix coveralls.travis] Post coverage from travis

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ Usage: mix coveralls.post <Options>
     --parallel          coveralls.io 'parallel' option (See coveralls.io API Reference)
     --subdir            Git repo sub directory: This will be added to the the front of file path, use if your covered
                         file paths reside within a subfolder of the git repo. Example: If your source file path is
-                        "test.rb", and your git repo root is one directory up making the file's relative path
-                        "src/lib/test.rb", then the sub directory should be: "src/lib" (from coveralls.io)
+                        "test.ex", and your git repo root is one directory up making the file's relative path
+                        "src/lib/test.ex", then the sub directory should be: "src/lib" (from coveralls.io)
     --rootdir           This will be stripped from the file path in order to resolve the relative path of this repo's
                         files. It should be the path to your git repo's root on your CI build environment. This is not
                         needed if your source file path is already relative. It's used to pull the source file from the
-                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.rb",
+                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.ex",
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
 ```

--- a/lib/excoveralls/post.ex
+++ b/lib/excoveralls/post.ex
@@ -16,7 +16,9 @@ defmodule ExCoveralls.Post do
     Jason.encode!(%{
       repo_token: options[:token],
       service_name: options[:service_name],
+      service_number: options[:service_number],
       source_files: source_info,
+      parallel: options[:parallel],
       git: generate_git_info(options)
     })
   end

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -46,12 +46,12 @@ Usage: mix coveralls.post <Options>
     --parallel          coveralls.io 'parallel' option (See coveralls.io API Reference)
     --subdir            Git repo sub directory: This will be added to the the front of file path, use if your covered
                         file paths reside within a subfolder of the git repo. Example: If your source file path is
-                        "test.rb", and your git repo root is one directory up making the file's relative path
-                        "src/lib/test.rb", then the sub directory should be: "src/lib" (from coveralls.io)
+                        "test.ex", and your git repo root is one directory up making the file's relative path
+                        "src/lib/test.ex", then the sub directory should be: "src/lib" (from coveralls.io)
     --rootdir           This will be stripped from the file path in order to resolve the relative path of this repo's
                         files. It should be the path to your git repo's root on your CI build environment. This is not
                         needed if your source file path is already relative. It's used to pull the source file from the
-                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.rb",
+                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.ex",
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
 """

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -42,6 +42,18 @@ Usage: mix coveralls.post <Options>
     -c (--committer)    Committer name ('COMMITTER' column at coveralls.io page)
     -m (--message)      Commit message ('COMMIT' column at coveralls.io page)
     -s (--sha)          Commit SHA (required when not using Travis)
+    --build             Service number ('BUILDS' column at coveralls.io page)
+    --parallel          coveralls.io 'parallel' option (See coveralls.io API Reference)
+    --subdir            Git repo sub directory: This will be added to the the front of file path, use if your covered
+                        file paths reside within a subfolder of the git repo. Example: If your source file path is
+                        "test.rb", and your git repo root is one directory up making the file's relative path
+                        "src/lib/test.rb", then the sub directory should be: "src/lib" (from coveralls.io)
+    --rootdir           This will be stripped from the file path in order to resolve the relative path of this repo's
+                        files. It should be the path to your git repo's root on your CI build environment. This is not
+                        needed if your source file path is already relative. It's used to pull the source file from the
+                        github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.rb",
+                        and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
+                        coveralls.io)
 """
   end
 end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -33,15 +33,7 @@ defmodule Mix.Tasks.Coveralls do
         message: "Please specify 'test_coverage: [tool: ExCoveralls]' in the 'project' section of mix.exs"
     end
 
-    switches = [
-      filter: :string,
-      output_dir: :string,
-      parallel: :boolean,
-      pro: :boolean,
-      sort: :string,
-      umbrella: :boolean,
-      verbose: :boolean
-    ]
+    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string]
     aliases = [f: :filter, u: :umbrella, v: :verbose, o: :output_dir]
     {args, common_options} = parse_common_options(args, switches: switches, aliases: aliases)
     all_options = options ++ common_options

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -85,8 +85,8 @@ defmodule Mix.Tasks.Coveralls do
       end
     end)
 
-    sub_dir_set? = "" != common_options[:subdir] |> to_string
-    root_dir_set? = "" != common_options[:rootdir] |> to_string
+    sub_dir_set? = common_options[:subdir] not in [nil, ""]
+    root_dir_set? = common_options[:rootdir] not in [nil, ""]
     if sub_dir_set? and root_dir_set? do
       raise ExCoveralls.InvalidOptionError,
                 message: "subdir and rootdir options are exclusive. please specify only one of them."
@@ -95,8 +95,8 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   def get_stats(stats, options) do
-    sub_dir_set? = "" != options[:subdir] |> to_string
-    root_dir_set? = "" != options[:rootdir] |> to_string
+    sub_dir_set? = options[:subdir] not in [nil, ""]
+    root_dir_set? = options[:rootdir] not in [nil, ""]
 
     cond do
       sub_dir_set? ->

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -85,8 +85,8 @@ defmodule Mix.Tasks.Coveralls do
       end
     end)
 
-    sub_dir_set? = not common_options[:subdir] in [nil, ""]
-    root_dir_set? = not common_options[:rootdir] in [nil, ""]
+    sub_dir_set? = not (common_options[:subdir] in [nil, ""])
+    root_dir_set? = not (common_options[:rootdir] in [nil, ""])
     if sub_dir_set? and root_dir_set? do
       raise ExCoveralls.InvalidOptionError,
                 message: "subdir and rootdir options are exclusive. please specify only one of them."
@@ -95,8 +95,8 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   def get_stats(stats, options) do
-    sub_dir_set? = not options[:subdir] in [nil, ""]
-    root_dir_set? = not options[:rootdir] in [nil, ""]
+    sub_dir_set? = not (options[:subdir] in [nil, ""])
+    root_dir_set? = not (options[:rootdir] in [nil, ""])
 
     cond do
       sub_dir_set? ->

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -85,8 +85,8 @@ defmodule Mix.Tasks.Coveralls do
       end
     end)
 
-    sub_dir_set? = common_options[:subdir] not in [nil, ""]
-    root_dir_set? = common_options[:rootdir] not in [nil, ""]
+    sub_dir_set? = not common_options[:subdir] in [nil, ""]
+    root_dir_set? = not common_options[:rootdir] in [nil, ""]
     if sub_dir_set? and root_dir_set? do
       raise ExCoveralls.InvalidOptionError,
                 message: "subdir and rootdir options are exclusive. please specify only one of them."
@@ -95,8 +95,8 @@ defmodule Mix.Tasks.Coveralls do
   end
 
   def get_stats(stats, options) do
-    sub_dir_set? = options[:subdir] not in [nil, ""]
-    root_dir_set? = options[:rootdir] not in [nil, ""]
+    sub_dir_set? = not options[:subdir] in [nil, ""]
+    root_dir_set? = not options[:rootdir] in [nil, ""]
 
     cond do
       sub_dir_set? ->

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -145,9 +145,9 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
-              service_name: "dummy_service_name", branch: "branch",
+              service_name: "dummy_service_name", service_number: "", branch: "branch",
               committer: "committer", sha: "asdf", message: "message",
-              umbrella: nil, verbose: nil, args: []])
+              umbrella: nil, verbose: nil, parallel: nil, rootdir: "", subdir: "", args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
@@ -165,9 +165,9 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "token",
-              service_name: "excoveralls", branch: "",
+              service_name: "excoveralls", service_number: "", branch: "",
               committer: "", sha: "", message: "[no commit message]",
-              umbrella: nil, verbose: nil, args: []])
+              umbrella: nil, verbose: nil, parallel: nil, rootdir: "", subdir: "", args: []])
 
     if org_token != nil do
       System.put_env("COVERALLS_REPO_TOKEN", org_token)

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -140,14 +140,14 @@ defmodule Mix.Tasks.CoverallsTest do
     System.put_env("COVERALLS_REPO_TOKEN", "dummy_token")
     System.put_env("COVERALLS_SERVICE_NAME", "dummy_service_name")
 
-    args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf"]
+    args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf", "--rootdir", "umbrella0/", "--subdir", "", "--build", "1"]
     Mix.Tasks.Coveralls.Post.run(args)
     assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
-              service_name: "dummy_service_name", service_number: "", branch: "branch",
+              service_name: "dummy_service_name", service_number: "1", branch: "branch",
               committer: "committer", sha: "asdf", message: "message",
-              umbrella: nil, verbose: nil, parallel: nil, rootdir: "", subdir: "", args: []])
+              umbrella: nil, verbose: nil, parallel: nil, rootdir: "umbrella0/", subdir: "", args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
@@ -200,32 +200,58 @@ defmodule Mix.Tasks.CoverallsTest do
     end
   end
 
-  test_with_mock "post with default switches",
-  	ExCoveralls.Poster, [execute: fn(_, _) -> :ok end] do
-			non_standard_args = ["--non_standard"]
+  describe "options and arguments check for post" do
+    test_with_mock "post with default switches",
+      ExCoveralls.Poster, [execute: fn(_, _) -> :ok end] do
+        non_standard_args = ["--non_standard"]
 
-			post_args = [
-				"--token", "a_token",
-				"--sha", "asdf",
-				"--name", "a_name",
-				"--committer", "My Name",
-				"--branch", "my_branch",
-				"--message", "commit message",
-				"--umbrella"
-			] ++ non_standard_args
+        post_args = [
+          "--token", "a_token",
+          "--sha", "asdf",
+          "--name", "a_name",
+          "--build", "build_num",
+          "--committer", "My Name",
+          "--branch", "my_branch",
+          "--message", "commit message",
+          "--umbrella"
+        ]
+        post_args_with_subdir = post_args ++ ["--subdir", "sub_dir/"] ++ non_standard_args
+        Mix.Tasks.Coveralls.Post.run(post_args_with_subdir)
 
-			Mix.Tasks.Coveralls.Post.run(post_args)
+        excoveralls_config = ExCoveralls.ConfServer.get()
 
-			excoveralls_config = ExCoveralls.ConfServer.get()
+        assert(excoveralls_config[:token] == "a_token")
+        assert(excoveralls_config[:sha] == "asdf")
+        assert(excoveralls_config[:service_name] == "a_name")
+        assert(excoveralls_config[:service_number] == "build_num")
+        assert(excoveralls_config[:subdir] == "sub_dir/")
+        assert(excoveralls_config[:committer] == "My Name")
+        assert(excoveralls_config[:branch] == "my_branch")
+        assert(excoveralls_config[:message] == "commit message")
+        assert(excoveralls_config[:umbrella])
+        assert(excoveralls_config[:args] == ["--non_standard"])
 
-			assert(excoveralls_config[:token] == "a_token")
-			assert(excoveralls_config[:sha] == "asdf")
-			assert(excoveralls_config[:service_name] == "a_name")
-			assert(excoveralls_config[:committer] == "My Name")
-			assert(excoveralls_config[:branch] == "my_branch")
-			assert(excoveralls_config[:message] == "commit message")
-			assert(excoveralls_config[:umbrella])
-			assert(excoveralls_config[:args] == ["--non_standard"])
+        post_args_with_rootdir = post_args ++ ["--rootdir", "root_dir/"] ++ non_standard_args
+        Mix.Tasks.Coveralls.Post.run(post_args_with_rootdir)
+
+        excoveralls_config = ExCoveralls.ConfServer.get()
+
+        assert(excoveralls_config[:rootdir] == "root_dir/")
+    end
+
+    test_with_mock "subdir and rootdir options are exclusive",
+      ExCoveralls.Poster, [execute: fn(_, _) -> :ok end] do
+
+        post_args = [
+          "--token", "a_token",
+          "--subdir", "subdir/",
+          "--rootdir", "rootdir"
+        ]
+
+        assert_raise ExCoveralls.InvalidOptionError, fn ->
+          Mix.Tasks.Coveralls.Post.run(post_args)
+        end
+    end
   end
 
   test "extract service name by param" do
@@ -283,6 +309,41 @@ defmodule Mix.Tasks.CoverallsTest do
 
     if org_name != nil do
       System.put_env("COVERALLS_REPO_TOKEN", org_name)
+    end
+  end
+
+  describe "get_stats/2" do
+    @test_path_1 "apps/umbrella1_app1/lib/umbrella1_app1.ex"
+    @test_path_2 "apps/umbrella1_app2/lib/umbrella1_app2.ex"
+    @test_stats [
+      %{
+        coverage: [],
+        name: @test_path_1,
+        source: "dummy_source2"
+      },
+      %{
+        coverage: [],
+        name: @test_path_2,
+        source: "dummy_source1"
+      }
+    ]
+
+    test "subdir is added to filepath" do
+      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: "umbrella1/"])
+      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1/") end)
+      |> Enum.all?(fn v -> v end)
+    end
+
+    test "rootdir is removed from filepath" do
+      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "apps/", subdir: ""])
+      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1_app") end)
+      |> Enum.all?(fn v -> v end)
+    end
+
+    test "filepath is untouched when no options for rootdir/subdir" do
+      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: ""])
+      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "apps/umbrella1_app") end)
+      |> Enum.all?(fn v -> v end)
     end
   end
 end

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -329,21 +329,27 @@ defmodule Mix.Tasks.CoverallsTest do
     ]
 
     test "subdir is added to filepath" do
-      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: "umbrella1/"])
-      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1/") end)
-      |> Enum.all?(fn v -> v end)
+      result =
+        Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: "umbrella1/"])
+        |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1/") end)
+        |> Enum.all?(fn v -> v end)
+      assert result
     end
 
     test "rootdir is removed from filepath" do
-      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "apps/", subdir: ""])
-      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1_app") end)
-      |> Enum.all?(fn v -> v end)
+      result =
+        Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "apps/", subdir: ""])
+        |> Enum.map(fn m -> assert String.starts_with?(m[:name], "umbrella1_app") end)
+        |> Enum.all?(fn v -> v end)
+      assert result
     end
 
     test "filepath is untouched when no options for rootdir/subdir" do
-      assert Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: ""])
-      |> Enum.map(fn m -> assert String.starts_with?(m[:name], "apps/umbrella1_app") end)
-      |> Enum.all?(fn v -> v end)
+      result =
+        Mix.Tasks.Coveralls.get_stats(@test_stats, [rootdir: "", subdir: ""])
+        |> Enum.map(fn m -> assert String.starts_with?(m[:name], "apps/umbrella1_app") end)
+        |> Enum.all?(fn v -> v end)
+      assert result
     end
   end
 end

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -351,5 +351,13 @@ defmodule Mix.Tasks.CoverallsTest do
         |> Enum.all?(fn v -> v end)
       assert result
     end
+
+    test "filepath is untouched when options for rootdir/subdir does not exist" do
+      result =
+        Mix.Tasks.Coveralls.get_stats(@test_stats, [])
+        |> Enum.map(fn m -> assert String.starts_with?(m[:name], "apps/umbrella1_app") end)
+        |> Enum.all?(fn v -> v end)
+      assert result
+    end
   end
 end

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -26,6 +26,7 @@ defmodule ExCoveralls.PostTest do
       Post.generate_json(@source_info, [
         token: "1234567890",
         service_name: "local",
+        service_number: "build_num_1",
         branch: "",
         committer: "",
         message: "",
@@ -37,7 +38,7 @@ defmodule ExCoveralls.PostTest do
          "\"parallel\":null," <>
          "\"repo_token\":\"1234567890\"," <>
          "\"service_name\":\"local\"," <>
-         "\"service_number\":null," <>
+         "\"service_number\":\"build_num_1\"," <>
          "\"source_files\":" <>
            "[{\"coverage\":[0,1,null,null]," <>
              "\"name\":\"test/fixtures/test.ex\"," <>

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -34,8 +34,10 @@ defmodule ExCoveralls.PostTest do
 
     assert json ==
        "{\"git\":{\"branch\":\"\",\"head\":{\"committer_name\":\"\",\"id\":\"\",\"message\":\"\"}}," <>
+         "\"parallel\":null," <>
          "\"repo_token\":\"1234567890\"," <>
          "\"service_name\":\"local\"," <>
+         "\"service_number\":null," <>
          "\"source_files\":" <>
            "[{\"coverage\":[0,1,null,null]," <>
              "\"name\":\"test/fixtures/test.ex\"," <>


### PR DESCRIPTION
Hi @parroty ,

This change tries to support the following options for `mix coveralls.post`:
1. parallel 
2. service_number 
3. git hub root directory path
4. git hub sub directory path

We use Jenkins, but since it's not directly supported by excoveralls, we are using `mix coveralls.post`.
For git hub root/sub directory path options, we have a repository that has multiple umbrella projects, and would like to specify different subdirectories for each umbrella project. When we send multiple posts within the same build for multiple umbrella projects, these options can be useful (before source files were not shown because of missing paths unless we put the path manually on UI).

Please let me know if this makes sense. If it does, I'll add more unit tests or documents, and try to finish this work.

P.S credit: this work was done during hackathon (oss-a-thon) event @ [TubiTV](https://tubitv.com/) which I currently work.