### PR TITLE
Update OTP version for github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['19.3']
+        otp: ['20.3']
         elixir: ['1.4', '1.5', '1.6', '1.7']
     env:
       MIX_ENV: test


### PR DESCRIPTION
For avoiding error with `runs-on: ubuntu-latest` runner.