### PR TITLE
Add background-color to base style for html report

### DIFF
--- a/lib/templates/html/htmlcov/_style.html.eex
+++ b/lib/templates/html/htmlcov/_style.html.eex
@@ -3,6 +3,7 @@
 body {
   font: 14px/1.6 "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin: 0;
+  background-color: #FFFFFF;
   color: #2C2C2C;
   border-top: 2px solid #ddd;
 }


### PR DESCRIPTION
Reasoning: when using certain HTML renderers - such as VSCode's extension [HTML Preview](https://marketplace.visualstudio.com/items?itemName=tht13.html-preview-vscode) - if the HTML page does not contain a background-color it will be transparent.

Which looks pretty bad on dark mode vscode:
![image](https://user-images.githubusercontent.com/5532443/109361939-cca17f80-7868-11eb-8b77-bb257723d9c2.png)

So I'm suggesting a basic background-color here just there's a base background-color overall.