### PR TITLE
use .exs file for config

### DIFF
--- a/lib/templates/html/htmlcov/coverage.html.eex
+++ b/lib/templates/html/htmlcov/coverage.html.eex
@@ -70,7 +70,7 @@
                         <tr>
                           <td class='line'><%= number %></td>
                           <td class='hits'></td>
-                          <td class='source'><%= ExCoveralls.Html.View.safe(line.source || ' ')  %></td>
+                          <td class='source'><%= ExCoveralls.Html.View.safe(line.source || " ")  %></td>
                         </tr>
                     <% end %>
                   <% end %>


### PR DESCRIPTION
I think it would be ideal to use .exs files instead of .json for configuration as it is the common format for elixir (credo, formatter, etc.). If you are willing to accept this PR I will update the documentation about upgrading.