### PR TITLE
Round coverage down

### DIFF
--- a/lib/excoveralls/stats.ex
+++ b/lib/excoveralls/stats.ex
@@ -188,7 +188,7 @@ defmodule ExCoveralls.Stats do
     if value == trunc(value) do
       trunc(value)
     else
-      Float.round(value, 1)
+      Float.floor(value, 1)
     end
   end
 

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -131,9 +131,9 @@ defmodule ExCoveralls.StatsTest do
     assert(results.coverage == 100)
   end
 
-  test "coverage stats are rounded to one decimal place" do
+  test "coverage stats are rounded down to one decimal place" do
     results = Stats.source(@fractional_source_info)
-    assert(results.coverage == 66.7)
+    assert(results.coverage == 66.6)
   end
 
 end


### PR DESCRIPTION
The coverage percentage is rounded down instead of rounding to the 
nearest tenth. This prevents a project with a large number of lines from 
passing with 100.0% coverage when there are actually lines that are not 
covered.

I can imagine wanting this to be a config option instead, while keeping the
current behavior as default, but I thought I'd throw out this PR to start the
discussion at least.