### PR TITLE
featue: minimum support for lcov

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ end
     - [[mix coveralls.html] Show coverage as HTML report](#mix-coverallshtml-show-coverage-as-html-report)
     - [[mix coveralls.json] Show coverage as JSON report](#mix-coverallsjson-show-coverage-as-json-report)
     - [[mix coveralls.xml] Show coverage as XML report](#mix-coverallsxml-show-coverage-as-xml-report)
+    - [[mix coveralls.lcov] Show coverage as lcov report (Experimental)](#mix-coverallslcov-show-coverage-as-lcov-report)
   - [coveralls.json](#coverallsjson)
       - [Stop Words](#stop-words)
       - [Exclude Files](#exclude-files)
@@ -356,6 +357,13 @@ The report follows a format supported by several code coverage services like Son
 Output to the shell is the same as running the command `mix coveralls` (to suppress this output, add `"print_summary": false` to your project's `coveralls.json` file). In a similar manner to `mix coveralls.detail`, reported source code can be filtered by specifying arguments using the `--filter` flag.
 
 Output reports are written to `cover/excoveralls.xml` by default, however, the path can be specified by overwriting the `"output_dir"` coverage option.
+
+### [mix coveralls.lcov] Show coverage as lcov report (Experimental)
+This task displays coverage information at the line level formatted as a lcov.
+The report follows a format supported by several code coverage services like VSCode extension(`ryanluker.vscode-coverage-gutters`).
+Output to the shell is the same as running the command `mix coveralls` (to suppress this output, add `"print_summary": false` to your project's `coveralls.json` file). In a similar manner to `mix coveralls.detail`, reported source code can be filtered by specifying arguments using the `--filter` flag.
+
+Output reports are written to `cover/lcov.info` by default, however, the path can be specified by overwriting the `"output_dir"` coverage option.
 
 ## coveralls.json
 `coveralls.json` provides settings for excoveralls.

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -18,6 +18,7 @@ defmodule ExCoveralls do
   alias ExCoveralls.Json
   alias ExCoveralls.Post
   alias ExCoveralls.Xml
+  alias ExCoveralls.Lcov
 
   @type_travis      "travis"
   @type_github      "github"
@@ -30,6 +31,7 @@ defmodule ExCoveralls do
   @type_json        "json"
   @type_post        "post"
   @type_xml         "xml"
+  @type_lcov        "lcov"
 
   @doc """
   This method will be called from mix to trigger coverage analysis.
@@ -97,6 +99,10 @@ defmodule ExCoveralls do
 
   def analyze(stats, @type_json, options) do
     Json.execute(stats, options)
+  end
+
+  def analyze(stats, @type_lcov, options) do
+    Lcov.execute(stats, options)
   end
 
   def analyze(stats, @type_xml, options) do

--- a/lib/excoveralls/lcov.ex
+++ b/lib/excoveralls/lcov.ex
@@ -26,7 +26,21 @@ defmodule ExCoveralls.Lcov do
       |> Enum.map(fn {k, v} -> {Integer.to_string(v), Integer.to_string(k)} end)
       |> Enum.map(fn {line, count} -> "DA:" <> line <> "," <> count end)
 
-    lines = ["TN:" <> stat.name, "SF:" <> stat.name] ++ da ++ ["end_of_record"]
+    foundlines =
+      stat.coverage
+      |> Enum.filter(fn v -> v != nil end)
+
+    lf = foundlines |> Enum.count()
+    lh = foundlines |> Enum.filter(fn v -> v > 0 end) |> Enum.count()
+
+    lines =
+      ["TN:" <> stat.name, "SF:" <> stat.name] ++
+        da ++
+        [
+          "LF:" <> Integer.to_string(lf),
+          "LH:" <> Integer.to_string(lh),
+          "end_of_record"
+        ]
 
     Enum.join(lines, "\n")
   end

--- a/lib/excoveralls/lcov.ex
+++ b/lib/excoveralls/lcov.ex
@@ -34,7 +34,7 @@ defmodule ExCoveralls.Lcov do
     lh = foundlines |> Enum.filter(fn v -> v > 0 end) |> Enum.count()
 
     lines =
-      ["TN:" <> stat.name, "SF:" <> stat.name] ++
+      ["TN:", "SF:" <> stat.name] ++
         da ++
         [
           "LF:" <> Integer.to_string(lf),

--- a/lib/excoveralls/lcov.ex
+++ b/lib/excoveralls/lcov.ex
@@ -1,0 +1,58 @@
+defmodule ExCoveralls.Lcov do
+  @moduledoc """
+  Generate lcov output for results.
+  """
+
+  @file_name "lcov.info"
+
+  @doc """
+  Provides an entry point for the module.
+  """
+  def execute(stats, options \\ []) do
+    generate_lcov(stats, Enum.into(options, %{})) |> write_file(options[:output_dir])
+
+    ExCoveralls.Local.print_summary(stats)
+  end
+
+  def generate_lcov(stats, _options) do
+    Enum.map(stats, fn stat -> generate_lcov_file(stat) end) |> Enum.join("\n")
+  end
+
+  def generate_lcov_file(stat) do
+    da =
+      stat.coverage
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {k, _v} -> k != nil end)
+      |> Enum.map(fn {k, v} -> {Integer.to_string(v), Integer.to_string(k)} end)
+      |> Enum.map(fn {line, count} -> "DA:" <> line <> "," <> count end)
+
+    lines = ["TN:" <> stat.name, "SF:" <> stat.name] ++ da ++ ["end_of_record"]
+
+    Enum.join(lines, "\n")
+  end
+
+  defp output_dir(output_dir) do
+    cond do
+      output_dir ->
+        output_dir
+
+      true ->
+        options = ExCoveralls.Settings.get_coverage_options()
+
+        case Map.fetch(options, "output_dir") do
+          {:ok, val} -> val
+          _ -> "cover/"
+        end
+    end
+  end
+
+  defp write_file(content, output_dir) do
+    file_path = output_dir(output_dir)
+
+    unless File.exists?(file_path) do
+      File.mkdir_p!(file_path)
+    end
+
+    File.write!(Path.expand(@file_name, file_path), content)
+  end
+end

--- a/lib/excoveralls/lcov.ex
+++ b/lib/excoveralls/lcov.ex
@@ -15,7 +15,8 @@ defmodule ExCoveralls.Lcov do
   end
 
   def generate_lcov(stats, _options) do
-    Enum.map(stats, fn stat -> generate_lcov_file(stat) end) |> Enum.join("\n")
+    lcov = Enum.map(stats, fn stat -> generate_lcov_file(stat) end) |> Enum.join("\n")
+    lcov <> "\n"
   end
 
   def generate_lcov_file(stat) do

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -170,6 +170,21 @@ defmodule Mix.Tasks.Coveralls do
     end
   end
 
+  defmodule Lcov do
+    @moduledoc """
+    Provides an entry point for outputting coveralls information
+    as a Lcov file.
+    """
+    use Mix.Task
+
+    @shortdoc "Output the test coverage as a Lcov file"
+    @preferred_cli_env :test
+
+    def run(args) do
+      Mix.Tasks.Coveralls.do_run(args, [ type: "lcov" ])
+    end
+  end
+
   defmodule Travis do
     @moduledoc """
     Provides an entry point for travis's script.

--- a/test/lcov_test.exs
+++ b/test/lcov_test.exs
@@ -1,0 +1,67 @@
+defmodule ExCoveralls.LcovTest do
+  use ExUnit.Case
+  import Mock
+  import ExUnit.CaptureIO
+  alias ExCoveralls.Lcov
+
+  @file_name "lcov.info"
+  @file_size 77
+  @test_output_dir "cover_test/"
+
+  @content     "defmodule Test do\n  def test do\n  end\nend\n"
+  @counts      [0, 1, nil, nil]
+  @source_info [%{name: "test/fixtures/test.ex",
+                  source: @content,
+                  coverage: @counts
+               }]
+
+  @stats_result "" <>
+    "----------------\n" <>
+    "COV    FILE                                        LINES RELEVANT   MISSED\n" <>
+    " 50.0% test/fixtures/test.ex                           4        2        1\n"  <>
+    "[TOTAL]  50.0%\n" <>
+    "----------------\n"
+
+  setup do
+    path = Path.expand(@file_name, @test_output_dir)
+
+    # Assert does not exist prior to write
+    assert(File.exists?(path) == false)
+    on_exit fn ->
+      if File.exists?(path) do
+        # Ensure removed after test
+        File.rm!(path)
+        File.rmdir!(@test_output_dir)
+      end
+    end
+
+    {:ok, report: path}
+  end
+
+  test_with_mock "generate lcov file", %{report: report}, ExCoveralls.Settings, [],
+      [
+        get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
+        get_file_col_width: fn -> 40 end,
+        get_print_summary: fn -> true end,
+        get_print_files: fn -> true end
+      ] do
+
+    assert capture_io(fn ->
+      Lcov.execute(@source_info)
+    end) =~ @stats_result
+
+    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nend_of_record))
+    %{size: size} = File.stat! report
+    assert(size == @file_size)
+  end
+
+  test "generate json file with output_dir parameter", %{report: report} do
+    assert capture_io(fn ->
+      Lcov.execute(@source_info, [output_dir: @test_output_dir])
+    end) =~ @stats_result
+
+    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nend_of_record))
+    %{size: size} = File.stat! report
+    assert(size == @file_size)
+  end
+end

--- a/test/lcov_test.exs
+++ b/test/lcov_test.exs
@@ -5,7 +5,7 @@ defmodule ExCoveralls.LcovTest do
   alias ExCoveralls.Lcov
 
   @file_name "lcov.info"
-  @file_size 77
+  @file_size 87
   @test_output_dir "cover_test/"
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
@@ -50,7 +50,7 @@ defmodule ExCoveralls.LcovTest do
       Lcov.execute(@source_info)
     end) =~ @stats_result
 
-    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nend_of_record))
+    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record))
     %{size: size} = File.stat! report
     assert(size == @file_size)
   end
@@ -60,7 +60,7 @@ defmodule ExCoveralls.LcovTest do
       Lcov.execute(@source_info, [output_dir: @test_output_dir])
     end) =~ @stats_result
 
-    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nend_of_record))
+    assert(File.read!(report) =~ ~s(TN:test/fixtures/test.ex\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record))
     %{size: size} = File.stat! report
     assert(size == @file_size)
   end


### PR DESCRIPTION
https://github.com/parroty/excoveralls/issues/104

The following are supported.
* `TN` empty
* `SF` name
* `DA`  line , execution count
* `LH`
* `LF`
* `end_of_record`