### PR TITLE
Add option for filtering out full covered files from HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ end
     - [[mix coveralls.html] Show coverage as HTML report](#mix-coverallshtml-show-coverage-as-html-report)
     - [[mix coveralls.json] Show coverage as JSON report](#mix-coverallsjson-show-coverage-as-json-report)
     - [[mix coveralls.xml] Show coverage as XML report](#mix-coverallsxml-show-coverage-as-xml-report)
-    - [[mix coveralls.lcov] Show coverage as lcov repor (Experimental)](#mix-coverallslcov-show-coverage-as-lcov-report-experimental)
+    - [[mix coveralls.lcov] Show coverage as lcov report (Experimental)](#mix-coverallslcov-show-coverage-as-lcov-report-experimental)
   - [coveralls.json](#coverallsjson)
       - [Stop Words](#stop-words)
       - [Exclude Files](#exclude-files)
@@ -424,6 +424,8 @@ to `false`:
   - A custom path for html reports. This defaults to the htmlcov report in the excoveralls lib.
 - `minimum_coverage`
   - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 if test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules. Should be expressed as a number between 0 and 100 signifying the minimum percentage of lines covered.
+- `html_filter_full_covered`
+  - A boolean, when `true` files with 100% coverage are not shown in the HTML report. Default to `false`.
 
 Example configuration file:
 
@@ -444,7 +446,8 @@ Example configuration file:
     "output_dir": "cover/",
     "template_path": "custom/path/to/template/",
     "minimum_coverage": 90,
-    "xml_base_dir": "custom/path/for/xml/reports/"
+    "xml_base_dir": "custom/path/for/xml/reports/",
+    "html_filter_full_covered": true
   }
 }
 ```

--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -21,7 +21,11 @@ defmodule ExCoveralls.Html do
 
   defp generate_report(map, output_dir) do
     IO.puts("Generating report...")
-    View.render(cov: map) |> write_file(output_dir)
+
+    filter_full_covered =
+      Map.get(ExCoveralls.Settings.get_coverage_options(), "html_filter_full_covered", false)
+
+    View.render(cov: map, filter_full_covered: filter_full_covered) |> write_file(output_dir)
   end
 
   defp output_dir(output_dir) do

--- a/lib/templates/html/htmlcov/coverage.html.eex
+++ b/lib/templates/html/htmlcov/coverage.html.eex
@@ -12,16 +12,18 @@
       <div id="menu">
         <li><a href='#overview'>overview</a></li>
         <%= for file <- @cov.files do %>
-          <li>
-            <span class='cov <%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'><%= file.coverage || 0 %></span>
-            <a href='#<%= file.filename %>'>
-              <% parts = String.split(file.filename, "/") %><% [b | s] = parts |> Enum.reverse |> Enum.reverse_slice(1, Enum.count(parts)) %>
-              <%= if Enum.count(s) do %>
-                <span class='dirname'><%= Enum.join(s, "/") <> "/" %></span>
-              <% end %>
-              <span class='basename'><%= b %></span>
-            </a>
-          </li>
+          <%= if not @filter_full_covered or file.coverage < 100 do %>
+            <li>
+              <span class='cov <%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'><%= file.coverage || 0 %></span>
+              <a href='#<%= file.filename %>'>
+                <% parts = String.split(file.filename, "/") %><% [b | s] = parts |> Enum.reverse |> Enum.reverse_slice(1, Enum.count(parts)) %>
+                <%= if Enum.count(s) do %>
+                  <span class='dirname'><%= Enum.join(s, "/") <> "/" %></span>
+                <% end %>
+                <span class='basename'><%= b %></span>
+              </a>
+            </li>
+          <% end %>
         <% end %>
       </div>
 
@@ -33,47 +35,49 @@
       </div>
       <div id='files'>
         <%= for file <- @cov.files do %>
-          <div class='file'>
-            <h2 id='<%= file.filename %>'><%= file.filename %></h2>
-            <div id='stats' class='<%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'>
-              <div class='percentage'><%= file.coverage || 0 %></div>
-              <div class='sloc'><%= file.sloc %></div>
-              <div class='hits'><%= file.hits %></div>
-              <div class='misses'><%= file.misses %></div>
-            </div>
-            <table id='source'>
-              <thead>
-                <tr>
-                  <th>Line</th>
-                  <th>Hits</th>
-                  <th>Source</th>
-                </tr>
-              <tbody>
-                <%= for {line, number} <- Enum.with_index(file.source) do %>
-                  <%= cond do %>
-                    <% line.coverage > 0 && line.coverage != nil -> %>
-                      <tr class='hit'>
-                        <td class='line'><%= number %></td>
-                        <td class='hits'><%= line.coverage %></td>
-                        <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
-                      </tr>
-                    <% 0 == line.coverage -> %>
-                      <tr class='miss'>
-                        <td class='line'><%= number %></td>
-                        <td class='hits'>0</td>
-                        <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
-                      </tr>
-                    <% true -> %>
-                      <tr>
-                        <td class='line'><%= number %></td>
-                        <td class='hits'></td>
-                        <td class='source'><%= ExCoveralls.Html.View.safe(line.source || ' ')  %></td>
-                      </tr>
+          <%= if not @filter_full_covered or file.coverage < 100 do %>
+            <div class='file'>
+              <h2 id='<%= file.filename %>'><%= file.filename %></h2>
+              <div id='stats' class='<%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'>
+                <div class='percentage'><%= file.coverage || 0 %></div>
+                <div class='sloc'><%= file.sloc %></div>
+                <div class='hits'><%= file.hits %></div>
+                <div class='misses'><%= file.misses %></div>
+              </div>
+              <table id='source'>
+                <thead>
+                  <tr>
+                    <th>Line</th>
+                    <th>Hits</th>
+                    <th>Source</th>
+                  </tr>
+                <tbody>
+                  <%= for {line, number} <- Enum.with_index(file.source) do %>
+                    <%= cond do %>
+                      <% line.coverage > 0 && line.coverage != nil -> %>
+                        <tr class='hit'>
+                          <td class='line'><%= number %></td>
+                          <td class='hits'><%= line.coverage %></td>
+                          <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
+                        </tr>
+                      <% 0 == line.coverage -> %>
+                        <tr class='miss'>
+                          <td class='line'><%= number %></td>
+                          <td class='hits'>0</td>
+                          <td class='source'><%= ExCoveralls.Html.View.safe line.source %></td>
+                        </tr>
+                      <% true -> %>
+                        <tr>
+                          <td class='line'><%= number %></td>
+                          <td class='hits'></td>
+                          <td class='source'><%= ExCoveralls.Html.View.safe(line.source || ' ')  %></td>
+                        </tr>
+                    <% end %>
                   <% end %>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+                </tbody>
+              </table>
+            </div>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -5,7 +5,7 @@ defmodule ExCoveralls.HtmlTest do
   alias ExCoveralls.Html
 
   @file_name "excoveralls.html"
-  @file_size 20191
+  @file_size 20375
   @test_output_dir "cover_test/"
   @test_template_path "lib/templates/html/htmlcov/"
 


### PR DESCRIPTION
I find it useful to focus on files not fully covered so I added an option for HTML reports that allows hiding all fully covered files.

This is only a proposal and some open points/missing things remain to be done but I would like to know your opinion before actually implement all of them.

I know that I can copy the `eex` template on my repo and add the needed if clause to obtain this behavior but I think this can be useful to other people.

Open points

- Should I add a disclaimer on the generated HTML that says that fully covered files are hidden?
- When this option is true should I hide the same files also from the terminal report?
- Test are still missing