### PR TITLE
chore: PathReader.base_path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add the following parameters.
     - It's an optional setting for skipping `MIX_ENV=test` part when executing `mix coveralls` tasks.
 - `test_coverage: [test_task: "espec"]` if you use Espec instead of default ExUnit.
 - `:excoveralls` in the deps function.
+- `Applicaton.put_env(:excoveralls, :base_path, "/bash/path")` an optional config if you want to set the application root path explicitly. By default this is the directory that the mix.exs file is in.
 
 ```elixir
 def project do

--- a/lib/excoveralls/path_reader.ex
+++ b/lib/excoveralls/path_reader.ex
@@ -8,7 +8,10 @@ defmodule ExCoveralls.PathReader do
   Returns the Mix.Project base path.
   """
   def base_path do
-    Enum.find(Mix.Project.config_files, &(&1 =~ ~r/mix.exs/)) |> Path.dirname
+    case Application.fetch_env(:excoveralls, :base_path) do
+      {:ok, base_path} -> base_path
+      :error -> Mix.Project.config_files() |> Enum.find(&(&1 =~ ~r/mix.exs/)) |> Path.dirname()
+    end
   end
 
   @doc """

--- a/test/mix/path_reader_test.exs
+++ b/test/mix/path_reader_test.exs
@@ -1,12 +1,20 @@
 defmodule ExCoveralls.PathReaderTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias ExCoveralls.PathReader
 
   test "gets project base path" do
-    assert(PathReader.base_path == File.cwd!)
+    assert(PathReader.base_path() == File.cwd!())
   end
 
   test "expand path" do
-    assert(PathReader.expand_path("test") == File.cwd! <> "/test")
+    assert(PathReader.expand_path("test") == File.cwd!() <> "/test")
+  end
+
+  test "use the application config when it is available" do
+    Application.put_env(:excoveralls, :base_path, "/base/path")
+    assert("/base/path" != File.cwd!())
+    assert(PathReader.base_path() == "/base/path")
+  after
+    Application.delete_env(:excoveralls, :base_path)
   end
 end


### PR DESCRIPTION
This patch changes the `PathReader.base_path` function to try reading
from the `Application` first, using the current method as a fallback
mechanism in case the config is not available.

The reason for this change is that we want to instrument a running
elixir app while executing some acceptance tests and
`Mix.Project.config_files` does not have all the necessary information
to infer the path.