### PR TITLE
Use `File.cwd!/0` for fetching base path

### DIFF
--- a/lib/excoveralls/path_reader.ex
+++ b/lib/excoveralls/path_reader.ex
@@ -10,7 +10,7 @@ defmodule ExCoveralls.PathReader do
   def base_path do
     case Application.fetch_env(:excoveralls, :base_path) do
       {:ok, base_path} -> base_path
-      :error -> Mix.Project.config_files() |> Enum.find(&(&1 =~ ~r/mix.exs/)) |> Path.dirname()
+      :error -> File.cwd!()
     end
   end
 


### PR DESCRIPTION
Otherwise it will fail if tests use [`in_project/3`][1] with confusing error about the fact that `nil` cannot be used in `Path.dirname/1`.

It should work 100% of the time as Mix will work only when ran in directory with `mix.exs` in it, and when running in umbrella it will change directory to the sub project before running tasks.

Ref hauleth/mix_unused#25

[1]: https://hexdocs.pm/mix/Mix.Project.html#in_project/3
