### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ------
 #### Changes
 - Fix for application base path identification logic.
-    - Use `File.cwd!/0` for fetching base path tests (#68).
+    - Use `File.cwd!/0` for fetching base path tests (#271).
+- Support Elixir 1.13 (#267).
 
 0.14.3
 ------


### PR DESCRIPTION
Fix typo and add elixir 1.13 notes in the CHANGELOG