### PR TITLE
Survive coveralls maintenance and outagle

### DIFF
--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -43,6 +43,8 @@ defmodule ExCoveralls.Poster do
       {:ok, status_code, _, _} when status_code in 200..299 ->
         {:ok, "Successfully uploaded the report to '#{endpoint}'."}
 
+      {:ok, 500 = _status_code, _, _client} ->        
+        {:ok, "API endpoint `#{endpoint}` is not available and return internal server error! Ignoring upload"}
       {:ok, status_code, _, client} ->
         {:ok, body} = :hackney.body(client)
 

--- a/lib/excoveralls/poster.ex
+++ b/lib/excoveralls/poster.ex
@@ -43,8 +43,10 @@ defmodule ExCoveralls.Poster do
       {:ok, status_code, _, _} when status_code in 200..299 ->
         {:ok, "Successfully uploaded the report to '#{endpoint}'."}
 
-      {:ok, 500 = _status_code, _, _client} ->        
+      {:ok, 500 = _status_code, _, _client} ->
         {:ok, "API endpoint `#{endpoint}` is not available and return internal server error! Ignoring upload"}
+      {:ok, 405 = _status_code, _, _client} ->
+        {:ok, "API endpoint `#{endpoint}` is not available due to maintenance! Ignoring upload"}
       {:ok, status_code, _, client} ->
         {:ok, body} = :hackney.body(client)
 

--- a/test/poster_test.exs
+++ b/test/poster_test.exs
@@ -21,4 +21,15 @@ defmodule PosterTest do
       assert ExCoveralls.Poster.execute("json") == :ok
     end) =~ ~r/timeout/
   end
+  test_with_mock "post json fails due internal server error", :hackney, [request: fn(_, _, _, _, _) -> {:ok, 500, "", ""} end] do
+    assert capture_io(fn ->
+      assert ExCoveralls.Poster.execute("json") == :ok
+    end) =~ ~r/internal server error/
+  end
+
+  test_with_mock "post json fails due to maintenance", :hackney, [request: fn(_, _, _, _, _) -> {:ok, 405, "", ""} end] do
+    assert capture_io(fn ->
+      assert ExCoveralls.Poster.execute("json") == :ok
+    end) =~ ~r/maintenance/
+  end
 end

--- a/test/poster_test.exs
+++ b/test/poster_test.exs
@@ -21,6 +21,7 @@ defmodule PosterTest do
       assert ExCoveralls.Poster.execute("json") == :ok
     end) =~ ~r/timeout/
   end
+
   test_with_mock "post json fails due internal server error", :hackney, [request: fn(_, _, _, _, _) -> {:ok, 500, "", ""} end] do
     assert capture_io(fn ->
       assert ExCoveralls.Poster.execute("json") == :ok


### PR DESCRIPTION
PR adds a special behaviour to the logic for uploading coverage reports that can survive the outage and maintenance of the remote UI (e.g. was the case for [coveralls](https://coveralls.io/)). I am not sure if it would be better to make this behaviour configurable, but in our case, it resulted in failing our PR within CI. Let me know if it makes sense and/or suggestions for improvement.