### PR TITLE
Minimum threshold support for json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.14.6
 ------
 #### Changes
-- Survive coveralls maintenance and outagle (#283).
+- Survive coveralls maintenance and outage (#283).
   - Better handling of coveralls.io errors (ex. 405, 500 status codes).
 
 0.14.5

--- a/lib/excoveralls/json.ex
+++ b/lib/excoveralls/json.ex
@@ -12,6 +12,8 @@ defmodule ExCoveralls.Json do
     generate_json(stats, Enum.into(options, %{})) |> write_file(options[:output_dir])
 
     ExCoveralls.Local.print_summary(stats)
+
+    ExCoveralls.Stats.ensure_minimum_coverage(stats)
   end
 
   def generate_json(stats, _options) do

--- a/test/json_test.exs
+++ b/test/json_test.exs
@@ -64,4 +64,36 @@ defmodule ExCoveralls.JsonTest do
     %{size: size} = File.stat! report
     assert(size == @file_size)
   end
+
+  test_with_mock "exit status code is 1 when actual coverage does not reach the minimum",
+      ExCoveralls.Settings, [
+        get_coverage_options: fn -> coverage_options(100) end,
+        get_file_col_width: fn -> 40 end,
+        get_print_summary: fn -> true end,
+        get_print_files: fn -> true end
+      ] do
+    output = capture_io(fn ->
+      assert catch_exit(Json.execute(@source_info)) == {:shutdown, 1}
+    end)
+    assert String.contains?(output, "FAILED: Expected minimum coverage of 100%, got 50%.")
+  end
+
+  test_with_mock "exit status code is 0 when actual coverage reaches the minimum",
+      ExCoveralls.Settings, [
+        get_coverage_options: fn -> coverage_options(49.9) end,
+        get_file_col_width: fn -> 40 end,
+        get_print_summary: fn -> true end,
+        get_print_files: fn -> true end
+      ] do
+    assert capture_io(fn ->
+      Json.execute(@source_info)
+    end) =~ @stats_result
+  end
+
+  defp coverage_options(minimum_coverage) do
+    %{
+      "minimum_coverage" => minimum_coverage,
+      "output_dir" => @test_output_dir,
+    }
+  end
 end

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -63,8 +63,10 @@ defmodule Mix.Tasks.CoverallsTest do
   end
 
   test_with_mock "doesn't pass through coveralls args", Runner, [run: fn(_, _) -> nil end] do
-    Mix.Tasks.Coveralls.run(["--include", "remote", "-x", "--unknown", "value", "--verbose", "-u", "--filter", "x"])
-    assert(called Runner.run("test", ["--cover", "--include", "remote", "-x", "--unknown", "value"]))
+    capture_io(fn ->
+	Mix.Tasks.Coveralls.run(["--include", "remote", "-x", "--unknown", "value", "--verbose", "-u", "--filter", "x"])
+	assert(called Runner.run("test", ["--cover", "--include", "remote", "-x", "--unknown", "value"]))
+    end)
   end
 
   test_with_mock "detail", Runner, [run: fn(_, _) -> nil end] do


### PR DESCRIPTION
Hi,

This pull request allows `mix coveralls.json` task return non-zero code, when the coverage is below minimum threshold.

I use this task in my [CI pipeline](https://github.com/exshome/exshome/blob/46c7d3dd2da09e71675ad5aeec58013fc731b60c/.github/workflows/ci.yml#L62). Now it passes, though coverage is below minimum threshold.

I have also noticed, that running tests via `mix test` printed some data to stdout. I have captured the output in that test.