### PR TITLE
Import coverdata if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Usage: mix coveralls <Options>
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
     --flagname          Job flag name which will be shown in the Coveralls UI
+    --import_cover      Directory from where '.coverdata' files should be imported and their results added to the report
 
 Usage: mix coveralls.detail [--filter file-name-pattern]
   Used to display coverage with detail

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -38,6 +38,12 @@ defmodule ExCoveralls do
   """
   def start(compile_path, opts) do
     Cover.compile(compile_path)
+
+    options = ConfServer.get()
+    if options[:import_cover] do
+      Cover.import(options[:import_cover])
+    end
+
     fn() ->
       execute(ConfServer.get, compile_path, opts)
     end
@@ -65,7 +71,7 @@ defmodule ExCoveralls do
     output = Keyword.get(opts, :output, "cover")
     File.mkdir_p!(output)
 
-    case :cover.export('#{output}/#{name}.coverdata') do
+    case Cover.export("#{output}/#{name}.coverdata") do
       :ok ->
         Mix.shell().info("Coverage data exported.")
 
@@ -77,7 +83,7 @@ defmodule ExCoveralls do
   defp store_stats(stats, options, compile_path) do
     {sub_app_name, _sub_app_path} =
       ExCoveralls.SubApps.find(options[:sub_apps], compile_path)
-    
+
     Stats.append_sub_app_name(stats, sub_app_name, options[:apps_path]) |> 
       Stats.update_paths(options) |>
       Enum.each(fn(stat) -> StatServer.add(stat) end)

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -27,6 +27,7 @@ Usage: mix coveralls <Options>
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
     --flagname          Job flag name which will be shown in the Coveralls UI
+    --import_cover      Directory from where '.coverdata' files should be imported and their results added to the report
 
 Usage: mix coveralls.detail [--filter file-name-pattern]
   Used to display coverage with detail

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Coveralls do
         message: "Please specify 'test_coverage: [tool: ExCoveralls]' in the 'project' section of mix.exs"
     end
 
-    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string, subdir: :string, rootdir: :string, flagname: :string]
+    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string, subdir: :string, rootdir: :string, flagname: :string, import_cover: :string]
     aliases = [f: :filter, u: :umbrella, v: :verbose, o: :output_dir]
     {args, common_options} = parse_common_options(args, switches: switches, aliases: aliases)
     all_options = options ++ common_options
@@ -269,6 +269,7 @@ defmodule Mix.Tasks.Coveralls do
         rootdir: :string,
         subdir: :string,
         build: :string,
+        import_cover: :string
       ]
       aliases = [f: :filter, u: :umbrella, v: :verbose]
       {remaining, options} = Mix.Tasks.Coveralls.parse_common_options(
@@ -292,7 +293,8 @@ defmodule Mix.Tasks.Coveralls do
           parallel:     options[:parallel],
           flag_name:    options[:flagname] || "",
           rootdir:      options[:rootdir] || "",
-          subdir:       options[:subdir] || ""
+          subdir:       options[:subdir] || "",
+          import_cover: options[:string]
         ])
     end
 

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.CoverallsTest do
              [type: "post", endpoint: nil, token: "dummy_token",
               service_name: "dummy_service_name", service_number: "1", branch: "branch",
               committer: "committer", sha: "asdf", message: "message",
-              umbrella: nil, verbose: nil, parallel: nil, flag_name: "arbitrary_value", rootdir: "umbrella0/", subdir: "", args: []])
+              umbrella: nil, verbose: nil, parallel: nil, flag_name: "arbitrary_value", rootdir: "umbrella0/", subdir: "", import_cover: nil, args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
@@ -175,7 +175,7 @@ defmodule Mix.Tasks.CoverallsTest do
              [type: "post", endpoint: nil, token: "token",
               service_name: "excoveralls", service_number: "", branch: "",
               committer: "", sha: "", message: "[no commit message]",
-              umbrella: nil, verbose: nil, parallel: nil, flag_name: "", rootdir: "", subdir: "", args: []])
+              umbrella: nil, verbose: nil, parallel: nil, flag_name: "", rootdir: "", subdir: "", import_cover: nil, args: []])
 
     if org_token != nil do
       System.put_env("COVERALLS_REPO_TOKEN", org_token)


### PR DESCRIPTION
This PR aims to handle the generation and import of coverage data.

For generation, we need to handle the `:export` and `:output` options given to `ExCoveralls.start/2` function. These options are described in Mix documentation for [test.coverage](https://hexdocs.pm/mix/1.14.1/Mix.Tasks.Test.Coverage.html#module-exporting-coverage).

For import, I added a new command line option (`--import-cover`) for selecting a directory from where cover data should be loaded. These files will be imported after module cover-compilation and their data will be added to the generated report.