### PR TITLE
Improve logging for a case with the missing source file

### DIFF
--- a/lib/excoveralls/cover.ex
+++ b/lib/excoveralls/cover.ex
@@ -28,9 +28,8 @@ defmodule ExCoveralls.Cover do
 
   def has_compile_info?(module) do
     with info when not is_nil(info) <- module.module_info(:compile),
-         path when not is_nil(path) <- Keyword.get(info, :source),
-         true <- File.exists?(path) do
-      true
+         path when not is_nil(path) <- Keyword.get(info, :source) do
+      file_exist?(module, path)
     else
       _e ->
         log_missing_source(module)
@@ -53,7 +52,20 @@ defmodule ExCoveralls.Cover do
     defp string_to_charlist(string), do: String.to_charlist(string)
   end
 
+  defp file_exist?(module, path) do
+    if File.exists?(path) do
+      true
+    else
+      log_missing_file(module, path)
+      false
+    end
+  end
+
   defp log_missing_source(module) do
     IO.puts :stderr, "[warning] skipping the module '#{module}' because source information for the module is not available."
+  end
+
+  defp log_missing_file(module, path) do
+    IO.puts :stderr, "[warning] skipping the module '#{module}' because source file with '#{path}' path does not exist"
   end
 end

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -29,7 +29,7 @@ defmodule CoverTest do
 
     assert capture_io(:stderr, fn ->
       refute Cover.has_compile_info?(TestMissing)
-    end) =~ "[warning] skipping the module 'Elixir.TestMissing' because source information for the module is not available."
+    end) =~ "[warning] skipping the module 'Elixir.TestMissing' because source file with '#{__DIR__}/fixtures/test_missing.ex' path does not exist"
   end
 
   test "has_compile_info?/1 with a mocked module raises warning and returns false" do


### PR DESCRIPTION
I would like to propose more granular logging for the case when module's source file does not exist.

### Problem

Recently we faced the issue with our CI sometimes producing wrong reports.

All compiled `.beam` files store the absolute path to the source of the module (which is accessed via `module_info`). We use `GitLab` for our CI and by default it checkout the source code with the following pattern:
```
{builds_dir}/$RUNNER_TOKEN_KEY/$CONCURRENT_ID/$NAMESPACE/$PROJECT_NAME
```
From one runner to another the absolute path is different. With caching in place new runner was pointing to the wrong address (which was correct on other machine).

### Outline

There is nothing wrong with the library itself but I believe more explicit logging message would've helped us to spot the issue faster.

_Initially, I made a wrong assumption that there is a problem with accessing `module_info` function (since I saw the source files being in place) and went wrong direction._

[Same issue described in here.](https://ananthakumaran.in/2022/08/26/elixir-ci-cache.html)

---

Let me know if that make sense or you need more information on the problem itself.