### PR TITLE
add .coverdata file export

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following are example projects.
 Add the following parameters.
 
 - `test_coverage: [tool: ExCoveralls]` for using ExCoveralls for coverage reporting.
+- `test_coverage: [tool: ExCoveralls, export: "cov"]` for exporting data to `cover/cov.coverdata`
 - `preferred_cli_env: [coveralls: :test]` for running `mix coveralls` in `:test` env by default
     - It's an optional setting for skipping `MIX_ENV=test` part when executing `mix coveralls` tasks.
 - `test_coverage: [test_task: "espec"]` if you use Espec instead of default ExUnit.

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExCoveralls.Mixfile do
   def project do
     [
       app: :excoveralls,
-      version: "0.15.1",
+      version: "0.15.2",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),


### PR DESCRIPTION
The command `mix test --cover --export-coverage XXX` exports the coverage data when using the default coverage tool of Elixir, but does not export anything when ExCoveralls is in use. This PR fixes this behavior.  It makes ExCoverall work just like the standard Elixir tool.