### PR TITLE
Ignore single next line

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,18 @@ defmodule MyModule do
 end
 ```
 
+Use comment `coveralls-ignore-next-line` to ignore only the next line.
+
+```elixir
+defmodule MyModule do
+  def covered do
+    # coveralls-ignore-next-line
+    "ignored"
+    "covered"
+  end
+end
+```
+
 ### Silence OTP Cover Warnings
 To remove OTP warnings about modules or specific logging, you can copy the `cover.erl` file under `src/` of your Elixir project and modify it to remove the warnings, as a tentative solution.
 

--- a/test/ignore_test.exs
+++ b/test/ignore_test.exs
@@ -2,7 +2,7 @@ defmodule ExCoveralls.IgnoreTest do
   use ExUnit.Case
   alias ExCoveralls.Ignore
 
-  @content     """
+  @block_content     """
   defmodule Test do
     def test do
     end
@@ -12,15 +12,63 @@ defmodule ExCoveralls.IgnoreTest do
     #coveralls-ignore-stop
   end
   """
-  @counts      [0, 0, 0, nil, 0, 0, nil, 0, 0]
-  @source_info [%{name: "test/fixtures/test.ex",
-                 source: @content,
-                 coverage: @counts
+  @block_counts      [0, 0, 0, nil, 0, 0, nil, 0, 0]
+  @block_source_info [%{name: "test/fixtures/test.ex",
+                 source: @block_content,
+                 coverage: @block_counts
                }]
 
-  test "filter ignored lines returns valid list" do
-    info = Ignore.filter(@source_info) |> Enum.at(0)
-    assert(info[:source]   == @content)
+  @single_line_content     """
+  defmodule Test do
+    def test do
+    end
+    #coveralls-ignore-next-line
+    def test_ignored do
+    end
+    def test_not_ignored do
+    end
+  end
+  """
+  @single_line_counts      [0, 0, 0, nil, 0, 0, 0, 0, 0, 0]
+  @single_line_source_info [%{name: "test/fixtures/test.ex",
+                 source: @single_line_content,
+                 coverage: @single_line_counts
+               }]
+
+  @mixed_content     """
+  defmodule Test do
+    def test do
+    end
+    #coveralls-ignore-start
+    def test_ignored do
+    #coveralls-ignore-next-line
+    end
+    #coveralls-ignore-stop
+    def test_not_ignored do
+    end
+  end
+  """
+  @mixed_counts      [0, 0, 0, nil, 0, nil, 0, nil, 0, 0, 0, 0]
+  @mixed_source_info [%{name: "test/fixtures/test.ex",
+                 source: @mixed_content,
+                 coverage: @mixed_counts
+               }]
+
+  test "filter ignored lines with start/stop block returns valid list" do
+    info = Ignore.filter(@block_source_info) |> Enum.at(0)
+    assert(info[:source]   == @block_content)
     assert(info[:coverage] == [0, 0, 0, nil, nil, nil, nil, 0, 0])
+  end
+
+  test "filter ignored lines with next-line returns valid list" do
+    info = Ignore.filter(@single_line_source_info) |> Enum.at(0)
+    assert(info[:source]   == @single_line_content)
+    assert(info[:coverage] == [0, 0, 0, nil, nil, 0, 0, 0, 0, 0])
+  end
+
+  test "filter ignored lines with next-line inside start/stop block returns valid list" do
+    info = Ignore.filter(@mixed_source_info) |> Enum.at(0)
+    assert(info[:source]   == @mixed_content)
+    assert(info[:coverage] == [0, 0, 0, nil, nil, nil, nil, nil, 0, 0, 0, 0])
   end
 end


### PR DESCRIPTION
Allows to ignore the coverage for the following line of code, by putting a new type of comment `# coveralls-ignore-next-line`.

Ignoring a single line is a common use case, which currently can be done by wrapping the code between the "start" and "stop" comments. If we can achieve the same with just one comment, this produces less visual noise and leaves more space for the useful code.

Resolves #219