### PR TITLE
Add coveralls.multiple command

### DIFF
--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -58,8 +58,9 @@ defmodule ExCoveralls do
     if options[:umbrella] do
       store_stats(stats, options, compile_path)
     else
-      Stats.update_paths(stats, options) |>
-        analyze(options[:type] || "local", options)
+      types = List.wrap(options[:type] || "local")
+      stats = Stats.update_paths(stats, options)
+      Enum.each(types, &analyze(stats, &1, options))
     end
   after
     if name = opts[:export] do

--- a/lib/excoveralls/conf_server.ex
+++ b/lib/excoveralls/conf_server.ex
@@ -5,6 +5,7 @@ defmodule ExCoveralls.ConfServer do
 
   @ets_table :excoveralls_conf_server
   @ets_key :config_key
+  @ets_summary_key :summary_key
 
   @doc """
   Initialize the data-store table.
@@ -40,5 +41,18 @@ defmodule ExCoveralls.ConfServer do
     start()
     :ets.insert(@ets_table, {@ets_key, value})
     value
+  end
+  
+  def summary_printed do 
+    start()
+    :ets.insert(@ets_table, {@ets_summary_key, true})
+  end
+  
+  def summary_printed? do 
+    start()
+    
+    @ets_table
+    |> :ets.lookup(@ets_summary_key)
+    |> Keyword.get(@ets_summary_key, false)
   end
 end

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -2,6 +2,8 @@ defmodule ExCoveralls.Local do
   @moduledoc """
   Locally displays the result to screen.
   """
+  
+  
 
   defmodule Count do
     @moduledoc """
@@ -44,8 +46,9 @@ defmodule ExCoveralls.Local do
   """
   def print_summary(stats, options \\ []) do
     enabled = ExCoveralls.Settings.get_print_summary
-    if enabled do
-      coverage(stats, options) |> IO.puts
+    if enabled and not ExCoveralls.ConfServer.summary_printed?() do
+      coverage(stats, options) |> IO.puts()
+      ExCoveralls.ConfServer.summary_printed()
     end
   end
 

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -56,6 +56,13 @@ Usage: mix coveralls.post <Options>
     -s (--sha)          Commit SHA (required when not using Travis)
     --build             Service number ('BUILDS' column at coveralls.io page)
     --parallel          coveralls.io 'parallel' option (See coveralls.io API Reference)
+
+Usage: mix coveralls.multiple
+  Used to perform multiple coveralls task at once without need of re-running tests.
+  
+  <Options>
+    --type              Coveralls task to execute (can be given multiple times)
+                        e.g. 'mix coveralls.multiple --type html --type json'
 """
   end
 end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -310,4 +310,39 @@ defmodule Mix.Tasks.Coveralls do
       end
     end
   end
+  
+  defmodule Multiple do
+    @moduledoc """
+    Provides an entry point for executing multiple coveralls
+    task at once without re-running tests
+    """
+
+    use Mix.Task
+
+    @preferred_cli_env :test
+
+    def run(args) do
+      {parsed, _, _} = OptionParser.parse(args, strict: [type: :keep])
+
+      args = remove_type_args(args)
+      
+      case Keyword.get_values(parsed, :type) do
+        [] -> raise ExCoveralls.InvalidOptionError, message: "type argument is required"
+        types -> Mix.Tasks.Coveralls.do_run(args, type: types)
+      end
+    end
+    
+    defp remove_type_args(args) do
+      {res, _} =
+        Enum.reduce(args, {[], nil}, fn entry, {buffer, acc} ->
+          case {entry, acc} do
+            {_, "--type" }-> {buffer, nil}
+            {"--type", _} -> {buffer, "--type"}
+            {el, _} -> {[el | buffer], nil}
+          end
+        end)
+        
+        Enum.reverse(res)
+    end
+  end
 end

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -24,6 +24,7 @@ defmodule ExCoveralls.HtmlTest do
     "----------------\n"
 
   setup do
+    ExCoveralls.ConfServer.clear()
     path = Path.expand(@file_name, @test_output_dir)
 
     # Assert does not exist prior to write
@@ -34,6 +35,8 @@ defmodule ExCoveralls.HtmlTest do
         File.rm!(path)
         File.rmdir!(@test_output_dir)
       end
+      
+      ExCoveralls.ConfServer.clear()
     end
 
     {:ok, report: path}

--- a/test/json_test.exs
+++ b/test/json_test.exs
@@ -23,6 +23,7 @@ defmodule ExCoveralls.JsonTest do
     "----------------\n"
 
   setup do
+    ExCoveralls.ConfServer.clear()
     path = Path.expand(@file_name, @test_output_dir)
 
     # Assert does not exist prior to write
@@ -33,6 +34,8 @@ defmodule ExCoveralls.JsonTest do
         File.rm!(path)
         File.rmdir!(@test_output_dir)
       end
+      
+      ExCoveralls.ConfServer.clear()
     end
 
     {:ok, report: path}

--- a/test/lcov_test.exs
+++ b/test/lcov_test.exs
@@ -23,6 +23,7 @@ defmodule ExCoveralls.LcovTest do
     "----------------\n"
 
   setup do
+    ExCoveralls.ConfServer.clear()
     path = Path.expand(@file_name, @test_output_dir)
 
     # Assert does not exist prior to write
@@ -33,6 +34,8 @@ defmodule ExCoveralls.LcovTest do
         File.rm!(path)
         File.rmdir!(@test_output_dir)
       end
+      
+      ExCoveralls.ConfServer.clear()
     end
 
     {:ok, report: path}

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -37,6 +37,12 @@ defmodule ExCoveralls.LocalTest do
       "\e[31mdefmodule Test do\e[m\n\e[32m  def test do\e[m\n" <>
       "  end\n" <>
       "end"
+      
+  setup do
+    ExCoveralls.ConfServer.clear()
+    on_exit(fn -> ExCoveralls.ConfServer.clear() end)
+    :ok
+  end
 
   test "display source information" do
     assert(Local.source(@source_info) =~ @source_result)

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -87,6 +87,13 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get == [type: "html", args: []])
   end
 
+  test_with_mock "multiple", Runner, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.Multiple.run(["--type", "html", "--type", "json", "--export-coverage", "cover", "test/foo_test.exs"])
+    assert(called Runner.run("test", ["--cover", "--export-coverage", "cover", "test/foo_test.exs"]))
+    assert(ExCoveralls.ConfServer.get()[:type] == ["html", "json"])
+    assert(ExCoveralls.ConfServer.get()[:args] == ["--export-coverage", "cover", "test/foo_test.exs"])
+  end
+
   test_with_mock "json", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Json.run([])
     assert(called Runner.run("test", ["--cover"]))

--- a/test/xml_test.exs
+++ b/test/xml_test.exs
@@ -22,6 +22,7 @@ defmodule ExCoveralls.XmlTest do
     "----------------\n"
 
   setup do
+    ExCoveralls.ConfServer.clear()
     path = Path.expand(@file_name, @test_output_dir)
 
     # Assert does not exist prior to write
@@ -32,6 +33,8 @@ defmodule ExCoveralls.XmlTest do
         File.rm!(path)
         File.rmdir!(@test_output_dir)
       end
+      
+      ExCoveralls.ConfServer.clear()
     end
 
     {:ok, report: path}


### PR DESCRIPTION
This allows running multiple coveralls tasks at once without re-running all the tests.

Before:
```
mix coveralls.html
mix coveralls.json
```

After:
```
mix coveralls.multiple --type html --type json
```