### PR TITLE
Allow per-file minimum coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ to `false`:
   - A custom path for html reports. This defaults to the htmlcov report in the excoveralls lib.
 - `minimum_coverage`
   - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 if test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules. Should be expressed as a number between 0 and 100 signifying the minimum percentage of lines covered.
+  - Can also be set to a nested object of filepath and minimum coverage key-value pairs. If this is the case, then `mix coveralls` and `mix coveralls.html` tasks will exit with a status code of 1 if test coverage falls below the specified threshold for any of the configured files.
 - `html_filter_full_covered`
   - A boolean, when `true` files with 100% coverage are not shown in the HTML report. Default to `false`.
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,9 @@ to `false`:
   - A custom path for html reports. This defaults to the htmlcov report in the excoveralls lib.
 - `minimum_coverage`
   - When set to a number greater than 0, this setting causes the `mix coveralls` and `mix coveralls.html` tasks to exit with a status code of 1 if test coverage falls below the specified threshold (defaults to 0). This is useful to interrupt CI pipelines with strict code coverage rules. Should be expressed as a number between 0 and 100 signifying the minimum percentage of lines covered.
-  - Can also be set to a nested object of filepath and minimum coverage key-value pairs. If this is the case, then `mix coveralls` and `mix coveralls.html` tasks will exit with a status code of 1 if test coverage falls below the specified threshold for any of the configured files.
+- `minimum_file_coverage`
+  - A JSON object whose keys are filepaths, and whose values are numbers. When a filepath specifies a minimum coverage greater than 0, any `mix coveralls` or `mix coveralls.html` tasks will exit with a status code of 1 if that file's test coverage falls below the configured threshold. Should be expressed as a number between 0 and 100 signifying the minimum percentage of lines covered for any given file.
+  - When used in conjunction with `minimum_coverage`, overall project coverage is checked first before individual file coverages are checked.
 - `html_filter_full_covered`
   - A boolean, when `true` files with 100% coverage are not shown in the HTML report. Default to `false`.
 
@@ -450,6 +452,9 @@ Example configuration file:
     "output_dir": "cover/",
     "template_path": "custom/path/to/template/",
     "minimum_coverage": 90,
+    "minimum_file_coverage": {
+      "lib/my_app/example.ex": 100
+    },
     "xml_base_dir": "custom/path/for/xml/reports/",
     "html_filter_full_covered": true
   }

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -242,7 +242,7 @@ defmodule ExCoveralls.StatsTest do
                    ExCoveralls.Settings,
                    [],
                    get_coverage_options: fn ->
-                     %{"minimum_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
+                     %{"minimum_file_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
                    end do
       assert :ok =
                Stats.ensure_minimum_coverage(
@@ -259,7 +259,7 @@ defmodule ExCoveralls.StatsTest do
                    ExCoveralls.Settings,
                    [],
                    get_coverage_options: fn ->
-                     %{"minimum_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
+                     %{"minimum_file_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
                    end do
       assert :ok =
                Stats.ensure_minimum_coverage(
@@ -276,7 +276,7 @@ defmodule ExCoveralls.StatsTest do
                    ExCoveralls.Settings,
                    [],
                    get_coverage_options: fn ->
-                     %{"minimum_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
+                     %{"minimum_file_coverage" => %{"file_1.ex": 50, "file_2.ex": 15}}
                    end do
       assert log =
                capture_io(fn ->
@@ -300,7 +300,7 @@ defmodule ExCoveralls.StatsTest do
                    ExCoveralls.Settings,
                    [],
                    get_coverage_options: fn ->
-                     %{"minimum_coverage" => %{"does_not_exist.ex": 50}}
+                     %{"minimum_file_coverage" => %{"does_not_exist.ex": 50}}
                    end do
       assert :ok = Stats.ensure_minimum_coverage(stats.([%{name: "file_3.ex", coverage: 0}]))
     end


### PR DESCRIPTION
Ahoy!!

This PR allows you to have per-file minimum coverage when you have coverage options that looks like:

```json
{
  "coverage_options": {
    "minimum_coverage": 80,
    "minimum_file_coverage": {
      "lib/my_app/example.ex": 100
    }
  }
}
```

If any files don't meet the configured threshold, then you'll get an error as follows:

```sh
FAILED: Expected minimum coverage of 100% for `lib/my_app/billing/example.ex`, got 16.7%.
```

This should also close #130

WDYT @parroty?