### PR TITLE
Enforce minimum coverage in all test types

### DIFF
--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -57,12 +57,19 @@ defmodule ExCoveralls do
       Stats.report() |> 
       Enum.map(&Enum.into(&1, %{}))
 
-    if options[:umbrella] do
-      store_stats(stats, options, compile_path)
-    else
-      types = List.wrap(options[:type] || "local")
-      stats = Stats.update_paths(stats, options)
-      Enum.each(types, &analyze(stats, &1, options))
+    stats =
+      if options[:umbrella] do
+        store_stats(stats, options, compile_path)
+        stats
+      else
+        types = List.wrap(options[:type] || "local")
+        stats = Stats.update_paths(stats, options)
+        Enum.each(types, &analyze(stats, &1, options))
+        stats
+      end
+
+    if options[:enforce_minimum_coverage] do
+      Stats.ensure_minimum_coverage(stats)
     end
   after
     if name = opts[:export] do

--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -4,7 +4,6 @@ defmodule ExCoveralls.Cobertura do
   """
 
   alias ExCoveralls.Settings
-  alias ExCoveralls.Stats
 
   @file_name "cobertura.xml"
 
@@ -17,8 +16,6 @@ defmodule ExCoveralls.Cobertura do
     |> write_file(options[:output_dir])
 
     ExCoveralls.Local.print_summary(stats)
-
-    Stats.ensure_minimum_coverage(stats)
   end
 
   defp generate_xml(stats, _options) do

--- a/lib/excoveralls/html.ex
+++ b/lib/excoveralls/html.ex
@@ -15,8 +15,6 @@ defmodule ExCoveralls.Html do
     ExCoveralls.Local.print_summary(stats)
 
     Stats.source(stats, options[:filter]) |> generate_report(options[:output_dir])
-
-    Stats.ensure_minimum_coverage(stats)
   end
 
   defp generate_report(map, output_dir) do

--- a/lib/excoveralls/local.ex
+++ b/lib/excoveralls/local.ex
@@ -3,8 +3,6 @@ defmodule ExCoveralls.Local do
   Locally displays the result to screen.
   """
   
-  
-
   defmodule Count do
     @moduledoc """
     Stores count information for calculating coverage values.
@@ -22,8 +20,6 @@ defmodule ExCoveralls.Local do
     if options[:detail] == true do
       source(stats, options[:filter]) |> IO.puts
     end
-
-    ExCoveralls.Stats.ensure_minimum_coverage(stats)
   end
 
   @doc """

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -33,8 +33,13 @@ defmodule Mix.Tasks.Coveralls do
         message: "Please specify 'test_coverage: [tool: ExCoveralls]' in the 'project' section of mix.exs"
     end
 
-    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string, subdir: :string, rootdir: :string, flagname: :string, import_cover: :string]
+    switches = [
+      filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string,
+      output_dir: :string, subdir: :string, rootdir: :string, flagname: :string, import_cover: :string, enforce_minimum_coverage: :boolean
+    ]
+
     aliases = [f: :filter, u: :umbrella, v: :verbose, o: :output_dir]
+
     {args, common_options} = parse_common_options(args, switches: switches, aliases: aliases)
     all_options = options ++ common_options
     test_task = Mix.Project.config[:test_coverage][:test_task] || "test"
@@ -43,6 +48,13 @@ defmodule Mix.Tasks.Coveralls do
       if all_options[:umbrella] do
         sub_apps = ExCoveralls.SubApps.parse(Mix.Dep.Umbrella.loaded)
         all_options ++ [sub_apps: sub_apps, apps_path: Mix.Project.config[:apps_path]]
+      else
+        all_options
+      end
+
+    all_options =
+      if all_options[:type] in ["local", "html", "cobertura"] do
+        Keyword.put(all_options, :enforce_minimum_coverage, true)
       else
         all_options
       end

--- a/test/excoveralls_test.exs
+++ b/test/excoveralls_test.exs
@@ -59,4 +59,5 @@ defmodule ExCoverallsTest do
       ExCoveralls.analyze(@stats, "Undefined Type", [])
     end
   end
+
 end

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -68,37 +68,4 @@ defmodule ExCoveralls.HtmlTest do
     assert(size == @file_size)
   end
 
-  test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
-      ExCoveralls.Settings, [
-        get_coverage_options: fn -> coverage_options(100) end,
-        get_file_col_width: fn -> 40 end,
-        get_print_summary: fn -> true end,
-        get_print_files: fn -> true end
-      ] do
-    output = capture_io(fn ->
-      assert catch_exit(Html.execute(@source_info)) == {:shutdown, 1}
-    end)
-    assert String.contains?(output, "FAILED: Expected minimum coverage of 100%, got 50%.")
-  end
-
-  test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
-      ExCoveralls.Settings, [
-        get_coverage_options: fn -> coverage_options(49.9) end,
-        get_file_col_width: fn -> 40 end,
-        get_print_summary: fn -> true end,
-        get_print_files: fn -> true end
-      ] do
-    assert capture_io(fn ->
-      Html.execute(@source_info)
-    end) =~ @stats_result
-  end
-
-  defp coverage_options(minimum_coverage) do
-    %{
-      "minimum_coverage" => minimum_coverage,
-      "output_dir" => @test_output_dir,
-      "template_path" => @test_template_path
-    }
-  end
-
 end

--- a/test/local_test.exs
+++ b/test/local_test.exs
@@ -96,32 +96,6 @@ defmodule ExCoveralls.LocalTest do
     assert String.contains?(Local.coverage(@empty_source_info), "[TOTAL]   0.0%")
   end
 
-  test_with_mock "Exit status code is 1 when actual coverage does not reach the minimum",
-
-      ExCoveralls.Settings, [
-        get_coverage_options: fn -> %{"minimum_coverage" => 100} end,
-        get_file_col_width: fn -> 40 end,
-        get_print_summary: fn -> true end,
-        get_print_files: fn -> true end
-      ] do
-    output = capture_io(fn ->
-      assert catch_exit(Local.execute(@source_info)) == {:shutdown, 1}
-    end)
-    assert String.contains?(output, "FAILED: Expected minimum coverage of 100%, got 50%.")
-  end
-
-  test_with_mock "Exit status code is 0 when actual coverage reaches the minimum",
-      ExCoveralls.Settings, [
-        get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end,
-        get_file_col_width: fn -> 40 end,
-        get_print_summary: fn -> true end,
-        get_print_files: fn -> true end
-      ] do
-    assert capture_io(fn ->
-      Local.execute(@source_info)
-    end) =~ @stats_result
-  end
-
   test_with_mock "No output if print_summary is false",
       ExCoveralls.Settings, [
         get_coverage_options: fn -> %{"minimum_coverage" => 49.9} end,

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.CoverallsTest do
   test_with_mock "local", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.run([])
     assert(called Runner.run("test", ["--cover"]))
-    assert(ExCoveralls.ConfServer.get == [type: "local", args: []])
+    assert(ExCoveralls.ConfServer.get == [enforce_minimum_coverage: true, type: "local", args: []])
   end
 
   test "local with help option" do
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.CoverallsTest do
       Mix.Tasks.Coveralls.run(["--umbrella"])
       assert(called Runner.run("test", ["--cover"]))
       assert(ExCoveralls.ConfServer.get ==
-        [type: "local", umbrella: true, sub_apps: [], apps_path: nil, args: []])
+        [enforce_minimum_coverage: true, type: "local", umbrella: true, sub_apps: [], apps_path: nil, args: []])
     end)
   end
 
@@ -72,25 +72,25 @@ defmodule Mix.Tasks.CoverallsTest do
   test_with_mock "detail", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Detail.run([])
     assert(called Runner.run("test", ["--cover"]))
-    assert(ExCoveralls.ConfServer.get == [type: "local", detail: true, args: []])
+    assert(ExCoveralls.ConfServer.get == [enforce_minimum_coverage: true, type: "local", detail: true, args: []])
   end
 
   test_with_mock "detail and filter", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Detail.run(["--filter", "x"])
     assert(called Runner.run("test", ["--cover"]))
-    assert(ExCoveralls.ConfServer.get == [type: "local", detail: true, filter: "x", args: []])
+    assert(ExCoveralls.ConfServer.get == [enforce_minimum_coverage: true, type: "local", detail: true, filter: "x", args: []])
   end
 
   test_with_mock "html", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Html.run([])
     assert(called Runner.run("test", ["--cover"]))
-    assert(ExCoveralls.ConfServer.get == [type: "html", args: []])
+    assert(ExCoveralls.ConfServer.get == [enforce_minimum_coverage: true, type: "html", args: []])
   end
   
   test_with_mock "cobertura", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Cobertura.run([])
     assert(called Runner.run("test", ["--cover"]))
-    assert(ExCoveralls.ConfServer.get == [type: "cobertura", args: []])
+    assert(ExCoveralls.ConfServer.get == [enforce_minimum_coverage: true, type: "cobertura", args: []])
   end
 
   test_with_mock "multiple", Runner, [run: fn(_, _) -> nil end] do


### PR DESCRIPTION
Ahoy again!

This PR implements a new flag to `excoveralls`: `--enforce-minimum-coverage`. When this is provided, we always run `Stats.ensure_minimum_coverage/1` regardless of what testing type you're running.

For example:
```shell
mix coveralls.json --enforce-minimum-coverage
mix coveralls.github --enforce-minimum-coverage
...
```

I've refactored the existing type implementations that call `Stats.ensure_minimum_coverage/1` by default and removed these calls. Instead, when running `Mix.Tasks.Coveralls.do_run/2` I check to see if the type requested was either `html`, `local`, or `cobertuna` and if so, I automatically set `--enforce-minimum-coverage` to retain backwards behavioural compatibility.

Closes #297