### PR TITLE
Cobertura now handles defprotocol and defimpl definitions

### DIFF
--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -159,15 +159,12 @@ defmodule ExCoveralls.Cobertura do
   end
 
   defp module_name(source) do
-    case Regex.run(~r/^def(?:module|protocol|impl)\s+(.*)\s+do$/m, source, capture: :all_but_first) do
-
-      [module] ->
-        module
-
-      _ ->
-        [module] = Regex.run(~r/^-(?:module|protocol|impl)\((.*)\)\.$/m, source, capture: :all_but_first)
-        module
-    end
+    with nil <- Regex.run(~r/^def(?:module|protocol|impl)\s+(.*)\s+do$/m, source, capture: :all_but_first),
+         nil <- Regex.run(~r/^-module\((.*)\)\.$/m, source, capture: :all_but_first) do
+     "UNKNOWN_MODULE"
+    else
+     [module] -> module
+    end  
   end
 
   defp package_name(path, c_paths) do

--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -159,12 +159,13 @@ defmodule ExCoveralls.Cobertura do
   end
 
   defp module_name(source) do
-    case Regex.run(~r/^defmodule\s+(.*)\s+do$/m, source, capture: :all_but_first) do
+    case Regex.run(~r/^def(?:module|protocol|impl)\s+(.*)\s+do$/m, source, capture: :all_but_first) do
+
       [module] ->
         module
 
       _ ->
-        [module] = Regex.run(~r/^-module\((.*)\)\.$/m, source, capture: :all_but_first)
+        [module] = Regex.run(~r/^-(?:module|protocol|impl)\((.*)\)\.$/m, source, capture: :all_but_first)
         module
     end
   end

--- a/test/cobertura_test.exs
+++ b/test/cobertura_test.exs
@@ -198,4 +198,44 @@ defmodule ExCoveralls.CoberturaTest do
     assert String.ends_with?(source1, "/lib")
     assert String.ends_with?(source2, "/test/fixtures")
   end
+
+  test_with_mock "generate cobertura file with defprotocol", _, ExCoveralls.Settings, [],
+    get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
+    get_file_col_width: fn -> 40 end,
+    get_print_summary: fn -> true end,
+    get_print_files: fn -> true end do
+    content = "defprotocol TestProtocol do\n  def test(value)\nend\n"
+    counts = [0, 1, nil, nil]
+    source_info = [%{name: "test/fixtures/test_protocol.ex", source: content, coverage: counts}]
+
+    stats_result =
+      "" <>
+        "----------------\n" <>
+        "COV    FILE                                        LINES RELEVANT   MISSED\n" <>
+        " 50.0% test/fixtures/test_protocol.ex                  4        2        1\n" <>
+        "[TOTAL]  50.0%\n" <>
+        "----------------\n"
+
+    assert capture_io(fn -> Cobertura.execute(source_info) end) =~ stats_result
+  end
+
+  test_with_mock "generate cobertura file with defimpl", _, ExCoveralls.Settings, [],
+    get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
+    get_file_col_width: fn -> 40 end,
+    get_print_summary: fn -> true end,
+    get_print_files: fn -> true end do
+    content = "defimpl TestProtocol, for: Integer do\n  def test(value), do: \"integer!\" \nend\n"
+    counts = [0, 1, nil, nil]
+    source_info = [%{name: "test/fixtures/test_impl.ex", source: content, coverage: counts}]
+
+    stats_result =
+      "" <>
+        "----------------\n" <>
+        "COV    FILE                                        LINES RELEVANT   MISSED\n" <>
+        " 50.0% test/fixtures/test_impl.ex                      4        2        1\n" <>
+        "[TOTAL]  50.0%\n" <>
+        "----------------\n"
+
+    assert capture_io(fn -> Cobertura.execute(source_info) end) =~ stats_result
+  end
 end


### PR DESCRIPTION
A protocol  (`defprotocol`) or implementation (`defimpl`) definition covered during the tests triggers an error when using the cobertura formatter.

This PR fixes it.

<details>
  <summary>

```
** (MatchError) no match of right hand side value: nil
    (excoveralls 0.16.0) lib/excoveralls/cobertura.ex:168: ExCoveralls.Cobertura.module_name/1
```

</summary>

```
    (excoveralls 0.16.0) lib/excoveralls/cobertura.ex:99: anonymous fn/3 in ExCoveralls.Cobertura.generate_packages/2
    (elixir 1.14.2) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (excoveralls 0.16.0) lib/excoveralls/cobertura.ex:97: ExCoveralls.Cobertura.generate_packages/2
    (excoveralls 0.16.0) lib/excoveralls/cobertura.ex:74: ExCoveralls.Cobertura.generate_xml/2
    (excoveralls 0.16.0) lib/excoveralls/cobertura.ex:16: ExCoveralls.Cobertura.execute/2
    (elixir 1.14.2) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (excoveralls 0.16.0) lib/excoveralls.ex:65: ExCoveralls.execute/3
    (mix 1.14.2) lib/mix/tasks/test.ex:549: Mix.Tasks.Test.do_run/3
    (mix 1.14.2) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (excoveralls 0.16.0) lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix 1.14.2) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.2) lib/mix/cli.ex:84: Mix.CLI.run_task/2
    (elixir 1.14.2) lib/code.ex:1260: Code.require_file/2
```

</details>

ping @albertored for review! :pray: 
