### PR TITLE
Import `.coverdata` after test run and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,17 @@ end
     - [[mix coveralls.xml] Show coverage as XML report](#mix-coverallsxml-show-coverage-as-xml-report)
     - [[mix coveralls.lcov] Show coverage as lcov report (Experimental)](#mix-coverallslcov-show-coverage-as-lcov-report-experimental)
   - [coveralls.json](#coverallsjson)
-      - [Stop Words](#stop-words)
-      - [Exclude Files](#exclude-files)
-      - [Terminal Report Output](#terminal-report-output)
-      - [Coverage Options](#coverage-options)
+    - [Stop Words](#stop-words)
+    - [Exclude Files](#exclude-files)
+    - [Terminal Report Output](#terminal-report-output)
+    - [Coverage Options](#coverage-options)
+  - [Other Considerations](#other-considerations)
     - [Ignore Lines](#ignore-lines)
+    - [Silence OTP Cover Warnings](#silence-otp-cover-warnings)
+    - [Merging Coverage Results](#merging-coverage-results)
     - [Notes](#notes)
     - [Todo](#todo)
-  - [License](#license)
+- [License](#license)
 
 ### [mix coveralls] Show coverage
 Run the `MIX_ENV=test mix coveralls` command to show coverage information on localhost.
@@ -549,6 +552,6 @@ See the `mix test` [Coverage documentation](https://hexdocs.pm/mix/Mix.Tasks.Tes
 - It might not work well on projects which handle multiple project (Mix.Project) files.
     - Needs improvement on file-path handling.
 
-## License
+# License
 
 This source code is licensed under the MIT license. Copyright (c) 2013-present, parroty.

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ COV    FILE                                        LINES RELEVANT   MISSED
 ----------------
 ```
 
-Coverage data is imported after tests are run. If a test spawns additional subprocesses, for instance to run `mix test` on a generated test module, coverage data exported during those runs can be included in the final report.
+Coverage data is imported after tests are run.
 
 See the `mix test` [Coverage documentation](https://hexdocs.pm/mix/Mix.Tasks.Test.html#module-coverage) for more information on `.coverdata`.
 

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -41,13 +41,14 @@ defmodule ExCoveralls do
   def start(compile_path, opts) do
     Cover.compile(compile_path)
 
-    options = ConfServer.get()
-    if options[:import_cover] do
-      Cover.import(options[:import_cover])
-    end
-
     fn() ->
-      execute(ConfServer.get, compile_path, opts)
+      options = ConfServer.get()
+
+      if options[:import_cover] do
+        Cover.import(options[:import_cover])
+      end
+
+      execute(options, compile_path, opts)
     end
   end
 

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -27,7 +27,8 @@ Usage: mix coveralls <Options>
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
     --flagname          Job flag name which will be shown in the Coveralls UI
-    --import_cover      Directory from where '.coverdata' files should be imported and their results added to the report
+    --import-cover      Directory from where '.coverdata' files should be imported and their results added to the report.
+                        Coverdata is imported after tests are run.
 
 Usage: mix coveralls.detail [--filter file-name-pattern]
   Used to display coverage with detail


### PR DESCRIPTION
Hi friends! Thanks for such a great tool.

This PR adds additional documentation/usage for the `--import-cover` flag and makes a change that improves the ergonomics of integration test coverage.

* `.coverdata` is now imported just before `ExCoveralls.execute/3`, instead of during `ExCoveralls.start/2`. This allows coverage data generated during the test run to be included in the final report.
* Fixed a small error in documentation: `--import_cover` -> `--import-cover`
* Added a new section to the README with additional explanation and an example of `--import-cover` usage.

/cc @albertored, who first introduced this feature