### PR TITLE
Fix lcov 2.0 source file handling

### DIFF
--- a/lib/excoveralls/lcov.ex
+++ b/lib/excoveralls/lcov.ex
@@ -33,9 +33,10 @@ defmodule ExCoveralls.Lcov do
 
     lf = foundlines |> Enum.count()
     lh = foundlines |> Enum.filter(fn v -> v > 0 end) |> Enum.count()
+    sf = Path.expand(stat.name, ".")
 
     lines =
-      ["TN:", "SF:" <> stat.name] ++
+      ["TN:", "SF:" <> sf] ++
         da ++
         [
           "LF:" <> Integer.to_string(lf),

--- a/test/lcov_test.exs
+++ b/test/lcov_test.exs
@@ -5,12 +5,12 @@ defmodule ExCoveralls.LcovTest do
   alias ExCoveralls.Lcov
 
   @file_name "lcov.info"
-  @file_size 67
   @test_output_dir "cover_test/"
 
   @content     "defmodule Test do\n  def test do\n  end\nend\n"
   @counts      [0, 1, nil, nil]
-  @source_info [%{name: "test/fixtures/test.ex",
+  @test_file_name "test/fixtures/test.ex"
+  @source_info [%{name: @test_file_name,
                   source: @content,
                   coverage: @counts
                }]
@@ -53,9 +53,9 @@ defmodule ExCoveralls.LcovTest do
       Lcov.execute(@source_info)
     end) =~ @stats_result
 
-    assert(File.read!(report) =~ ~s(TN:\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record\n))
-    %{size: size} = File.stat! report
-    assert(size == @file_size)
+    source_file = Path.expand(@test_file_name, ".")
+
+    assert(File.read!(report) =~ ~s(TN:\nSF:#{source_file}\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record\n))
   end
 
   test "generate json file with output_dir parameter", %{report: report} do
@@ -63,8 +63,8 @@ defmodule ExCoveralls.LcovTest do
       Lcov.execute(@source_info, [output_dir: @test_output_dir])
     end) =~ @stats_result
 
-    assert(File.read!(report) =~ ~s(TN:\nSF:test/fixtures/test.ex\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record\n))
-    %{size: size} = File.stat! report
-    assert(size == @file_size)
+    source_file = Path.expand(@test_file_name, ".")
+
+    assert(File.read!(report) =~ ~s(TN:\nSF:#{source_file}\nDA:1,0\nDA:2,1\nLF:2\nLH:1\nend_of_record\n))
   end
 end


### PR DESCRIPTION
Prior to 2.0 being released, `genhtml` was much better about handling  source files from the following paths:

* `test/support/some_helper.ex`
* `lib/foo/bar.ex`

But after 2.0 was released, when rendering with `genhtml` the paths  would be mangled and look like the following:

* `test/support/test/support/some_helper.ex`
* `lib/foo/lib/foo/bar.ex`

I have tried in vain with many permutations of `--prefix` when running `genhtml` but the ultimate fix that made all of this go away was using the absolute path for the source file (`SF`).