### PR TITLE
Use explicit steps to remove 1.16 deprecation warning in Cobertura

### DIFF
--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -173,7 +173,7 @@ defmodule ExCoveralls.Cobertura do
     c_paths
     |> Enum.find_value(package_name, fn c_path ->
       if String.starts_with?(package_name, c_path) do
-        String.slice(package_name, (String.length(c_path) + 1)..-1)
+        String.slice(package_name, get_slice_range_for_package_name(c_path))
       else
         false
       end
@@ -181,6 +181,14 @@ defmodule ExCoveralls.Cobertura do
     |> Path.split()
     |> Enum.join(".")
     |> to_charlist()
+  end
+
+  # TODO: Remove when we require Elixir 1.12 as minimum and inline it with range syntax
+  if Version.match?(System.version(), ">= 1.12.0") do
+    # We use Range.new/3 because using x..y//step would give a syntax error on Elixir < 1.12
+    defp get_slice_range_for_package_name(c_path), do: Range.new(String.length(c_path) + 1, -1, 1)
+  else
+    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1
   end
 
   defp rate(valid_lines) when length(valid_lines) == 0, do: 0.0


### PR DESCRIPTION
Since Elixir v1.16 negative slices (steps) to `String.slice/2` have been deprecated and throws a warning for each call when running `mix coveralls.cobertura`.

Example warning:
> warning: negative steps are not supported in String.slice/2, pass 31..-1//1 instead

This PR removes the warning by using explicit steps as the warning message recommends. However since this library supports also v1.11, which does not support explicit steps yet, this PR conditionally calls `Range.new/3` instead of using `x..y//step`. Otherwise we would get a syntax error during compilation on v.1.11.

Let me know if there is anything else that needs to be done in this PR.