### PR TITLE
Revert "add missing step for Cobertura's range"

### DIFF
--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -188,7 +188,7 @@ defmodule ExCoveralls.Cobertura do
     # We use Range.new/3 because using x..y//step would give a syntax error on Elixir < 1.12
     defp get_slice_range_for_package_name(c_path), do: Range.new(String.length(c_path) + 1, -1, 1)
   else
-    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1//1
+    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1
   end
 
   defp rate(valid_lines) when length(valid_lines) == 0, do: 0.0


### PR DESCRIPTION
Reverts parroty/excoveralls#329 due to following errors.

```
== Compilation error in file lib/excoveralls/cobertura.ex ==
Error: ** (SyntaxError) lib/excoveralls/cobertura.ex:191:87: syntax error before: '/'
    (elixir 1.11.4) lib/kernel/parallel_compiler.ex:314: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
Error: Process completed with exit code 1.
```