### PR TITLE
Update Range to use function syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
             elixir: '1.11'
           - otp: '26.0'
             elixir: '1.15'
+          - otp: '27.0'
+            elixir: '1.17'
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -188,7 +188,7 @@ defmodule ExCoveralls.Cobertura do
     # We use Range.new/3 because using x..y//step would give a syntax error on Elixir < 1.12
     defp get_slice_range_for_package_name(c_path), do: Range.new(String.length(c_path) + 1, -1, 1)
   else
-    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1//1
+    defp get_slice_range_for_package_name(c_path), do: Range.new(String.length(c_path) + 1, -1)
   end
 
   defp rate(valid_lines) when length(valid_lines) == 0, do: 0.0

--- a/lib/excoveralls/cobertura.ex
+++ b/lib/excoveralls/cobertura.ex
@@ -188,7 +188,7 @@ defmodule ExCoveralls.Cobertura do
     # We use Range.new/3 because using x..y//step would give a syntax error on Elixir < 1.12
     defp get_slice_range_for_package_name(c_path), do: Range.new(String.length(c_path) + 1, -1, 1)
   else
-    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1
+    defp get_slice_range_for_package_name(c_path), do: (String.length(c_path) + 1)..-1//1
   end
 
   defp rate(valid_lines) when length(valid_lines) == 0, do: 0.0

--- a/test/settings_test.exs
+++ b/test/settings_test.exs
@@ -15,7 +15,8 @@ defmodule Excoveralls.SettingsTest do
 
   test "returns default file path" do
     assert(Settings.Files.default_file
-           |> Path.relative_to(File.cwd!) == "lib/excoveralls/../conf/coveralls.json")
+           |> Path.expand()
+           |> Path.relative_to(File.cwd!) == "lib/conf/coveralls.json")
   end
 
   test "returns custom file path" do


### PR DESCRIPTION
the inline syntax fails with elixir 1.11
I've also added elixir 1.17 to the matrix, as the tests were failing in that version due to some path resolution difference between 1.15 and 1.16

Closes #331 
Follow up to #329 