### PR TITLE
Elixir 1.18 compatibility

### DIFF
--- a/lib/excoveralls/stop_words.ex
+++ b/lib/excoveralls/stop_words.ex
@@ -14,7 +14,7 @@ defmodule ExCoveralls.StopWords do
     lines = String.split(source, "\n")
     list = Enum.zip(lines, coverage)
            |> Enum.map(fn(x) -> has_valid_line?(x, words) end)
-           |> List.zip
+           |> Enum.zip()
            |> Enum.map(&Tuple.to_list(&1))
     [source, coverage] = parse_filter_list(list)
     %{name: name, source: source, coverage: coverage}
@@ -25,9 +25,9 @@ defmodule ExCoveralls.StopWords do
 
   defp has_valid_line?({line, coverage}, words) do
     if find_stop_words(line, words) == false do
-      {line, coverage}
+      [line, coverage]
     else
-      {line, nil}
+      [line, nil]
     end
   end
 


### PR DESCRIPTION
When using excoveralls with elixir `main`, the following error is produced:

```
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for {"defmodule Test do", nil} of type Tuple. This protocol is implemented for the following type(s): Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
```

This is because we provide a list of tuples, but that is not valid according to the typespec `@spec zip([list()]) :: [tuple()]`. 

Since Elixir is deprecating `List.zip/1`, the code was slightly changed and a list of tuples is no longer accepted.

This PR switches to `Enum.zip/1`, and uses a list of lists instead of tuples. That should be compatible since Elixir 1.4 and avoid upcoming deprecations.