### PR TITLE
Add Custom Filename support for coveralls.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,11 @@ Output to the shell is the same as running the command `mix coveralls` (to suppr
 Upload a coverage report to Codecov using their [bash uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader)
 or to Code Climate using their [test-reporter](https://docs.codeclimate.com/docs/configuring-test-coverage).
 
-Output reports are written to `cover/excoveralls.json` by default, however, the path can be specified by overwriting the `"output_dir"` coverage option.
+Output reports are written to `cover/excoveralls.json` by default, however, the path can be specified by overwriting the `"output_dir"` coverage option. Additionally, the filename can be specified using the `export` option under `test_coverage` in your `mix.exs` i.e.
+
+`test_coverage: [tool: ExCoveralls, export: "my_awesome_report"]`
+
+*Note:* the .json extension will be added automatically to the export name. Defaults to `excoveralls` if not specified.
 
 ### [mix coveralls.xml] Show coverage as XML report
 This task displays coverage information at the source-code level formatted as a XML document.

--- a/lib/excoveralls.ex
+++ b/lib/excoveralls.ex
@@ -63,6 +63,9 @@ defmodule ExCoveralls do
     else
       types = List.wrap(options[:type] || "local")
       stats = Stats.update_paths(stats, options)
+
+      # Push all available options down
+      options = options ++ opts
       Enum.each(types, &analyze(stats, &1, options))
     end
   after

--- a/lib/excoveralls/json.ex
+++ b/lib/excoveralls/json.ex
@@ -10,7 +10,7 @@ defmodule ExCoveralls.Json do
   Provides an entry point for the module.
   """
   def execute(stats, options \\ []) do
-    generate_json(stats, Enum.into(options, %{})) |> write_file(options[:output_dir])
+    generate_json(stats, Enum.into(options, %{})) |> write_file(options)
 
     ExCoveralls.Local.print_summary(stats)
   end
@@ -34,12 +34,22 @@ defmodule ExCoveralls.Json do
     end
   end
 
-  defp write_file(content, output_dir) do
+  defp output_name(name) do
+    case name do
+      nil -> @file_name
+      name -> "#{name}.json"
+    end
+  end
+
+  defp write_file(content, options) do
+    output_dir = options[:output_dir]
+    name = output_name(options[:export])
+
     file_path = output_dir(output_dir)
     unless File.exists?(file_path) do
       File.mkdir_p!(file_path)
     end
-    File.write!(Path.expand(@file_name, file_path), content)
+    File.write!(Path.expand(name, file_path), content)
   end
 
 end

--- a/test/json_test.exs
+++ b/test/json_test.exs
@@ -4,7 +4,7 @@ defmodule ExCoveralls.JsonTest do
   import ExUnit.CaptureIO
   alias ExCoveralls.Json
 
-  @file_name "excoveralls.json"
+  @file_name "excoveralls"
   @file_size 136
   @test_output_dir "cover_test/"
 
@@ -24,31 +24,36 @@ defmodule ExCoveralls.JsonTest do
     "----------------\n"
 
   setup do
-    ExCoveralls.ConfServer.clear()
-    path = Path.expand(@file_name, @test_output_dir)
+    on_entry = fn name, path -> 
+      ExCoveralls.ConfServer.clear()
+      path = Path.expand("#{name}.json", path)
 
-    # Assert does not exist prior to write
-    assert(File.exists?(path) == false)
-    on_exit fn ->
+      # Assert does not exist prior to write
+      assert(File.exists?(path) == false)
+
+      path
+    end
+    on_exit = fn path, dir ->
       if File.exists?(path) do
         # Ensure removed after test
         File.rm!(path)
-        File.rmdir!(@test_output_dir)
+        File.rmdir!(dir)
       end
 
       ExCoveralls.ConfServer.clear()
     end
 
-    {:ok, report: path}
+    {:ok, on_entry: on_entry, on_exit: on_exit}
   end
 
-  test_with_mock "generate json file", %{report: report}, ExCoveralls.Settings, [],
+  test_with_mock "generate json file", %{on_entry: on_entry, on_exit: on_exit}, ExCoveralls.Settings, [],
       [
         get_coverage_options: fn -> %{"output_dir" => @test_output_dir} end,
         get_file_col_width: fn -> 40 end,
         get_print_summary: fn -> true end,
         get_print_files: fn -> true end
       ] do
+    report = on_entry.(@file_name, @test_output_dir)
 
     assert capture_io(fn ->
       Json.execute(@source_info)
@@ -66,9 +71,35 @@ defmodule ExCoveralls.JsonTest do
       } = Jason.decode!(File.read!(report)))
     %{size: size} = File.stat! report
     assert(size == @file_size)
+
+    on_exit.(report, @test_output_dir)
   end
 
-  test "generate json file with output_dir parameter", %{report: report} do
+  test "generate json file with output_dir parameter", %{on_entry: on_entry, on_exit: on_exit} do
+    report = on_entry.(@file_name, "coverme")
+    assert capture_io(fn ->
+      Json.execute(@source_info, [output_dir: "coverme"])
+    end) =~ @stats_result
+
+    assert(
+      %{
+        "source_files" => [
+          %{
+            "coverage" => [0, 1, nil, nil],
+            "name" => "test/fixtures/test.ex",
+            "source" => "defmodule Test do\n  def test do\n  end\nend\n"
+          }
+        ]
+      } = Jason.decode!(File.read!(report)))
+    %{size: size} = File.stat! report
+    assert(size == @file_size)
+
+    on_exit.(report, "coverme")
+  end
+
+  test "generate json file with custom filename", %{on_entry: on_entry, on_exit: on_exit} do
+    report = on_entry.("custom", @test_output_dir)
+
     assert capture_io(fn ->
       Json.execute(@source_info, [output_dir: @test_output_dir])
     end) =~ @stats_result
@@ -85,5 +116,7 @@ defmodule ExCoveralls.JsonTest do
       } = Jason.decode!(File.read!(report)))
     %{size: size} = File.stat! report
     assert(size == @file_size)
+
+    on_exit.(report, @test_output_dir)
   end
 end

--- a/test/json_test.exs
+++ b/test/json_test.exs
@@ -101,7 +101,7 @@ defmodule ExCoveralls.JsonTest do
     report = on_entry.("custom", @test_output_dir)
 
     assert capture_io(fn ->
-      Json.execute(@source_info, [output_dir: @test_output_dir])
+      Json.execute(@source_info, [output_dir: @test_output_dir, export: "custom"])
     end) =~ @stats_result
 
     assert(


### PR DESCRIPTION
# Problem
When running an umbrella app's coveralls in partitioned instances - a way to specify reports is needed for tools like CodeCov to [merge reports](https://docs.codecov.com/docs/github-4a-merging-reports) - this is helpful when running GH actions as a matrix for each app, or even if running the same app in partitions.

# Proposal
Leverage the same `export` flag that exists for `.coverdata` files and allow the name to be used instead of the hardcoded `excoveralls.json` if it exists. That way predictable filenames can be given and default behaviour preserved.


