### PR TITLE
Fix Json output name when export isn't set

### DIFF
--- a/lib/excoveralls/json.ex
+++ b/lib/excoveralls/json.ex
@@ -35,9 +35,10 @@ defmodule ExCoveralls.Json do
   end
 
   defp output_name(name) do
-    case name do
-      nil -> @file_name
-      name -> "#{name}.json"
+    if name do
+      "#{name}.json"
+    else
+      @file_name
     end
   end
 


### PR DESCRIPTION
By default `export` is set to `false`, with recent changes in #335 when `export` isn't set this results in the `json` be named to `false.json`. This breaks pipelines that expect the filename `excoveralls.json` to be used.

To be more precise, this is only when `export_coverage` and `partitions` aren't also set as well, then `export` is set to `false`.

See: https://github.com/elixir-lang/elixir/blob/029699735d8b3331316dd7362c5b3cfffe6f2602/lib/mix/lib/mix/tasks/test.ex#L578

And: https://github.com/elixir-lang/elixir/blob/029699735d8b3331316dd7362c5b3cfffe6f2602/lib/mix/lib/mix/tasks/test.ex#L582