### PR TITLE
Handle multiple types in `coveralls.multiple` when `--umbrella` is present

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -54,11 +54,13 @@ defmodule Mix.Tasks.Coveralls do
     Runner.run(test_task, ["--cover"] ++ args)
 
     if all_options[:umbrella] do
-      type = options[:type] || "local"
+      types = List.wrap(options[:type] || "local")
 
-      ExCoveralls.StatServer.get
-      |> MapSet.to_list
-      |> ExCoveralls.analyze(type, options)
+      Enum.each(types, fn type ->
+        ExCoveralls.StatServer.get
+        |> MapSet.to_list
+        |> ExCoveralls.analyze(type, options)
+      end)
     end
   end
 


### PR DESCRIPTION
When the `--umbrella` flag isn't passed, `excoveralls` actually knows how to handle multiple types (it invokes `ExCoveralls.analyze/3` for each of them), but if the option is present, then we handle the types as if it were only one

https://github.com/parroty/excoveralls/blob/e9776c9a59c3067774f9af5e116ef76dbf8af6ab/lib/excoveralls.ex#L61-L69

This results in a function clause error, which can be replicated in the umbrella example repo, https://github.com/parroty/excoveralls_umbrella
```
excoveralls_umbrella on  master [!] via 💧 v1.18.2
➜ mix coveralls.multiple --umbrella --type html --type cobertura
==> subapp0
Running ExUnit with seed: 57138, max_cases: 24

..
Finished in 0.00 seconds (0.00s async, 0.00s sync)
2 tests, 0 failures
==> subapp1
Running ExUnit with seed: 57138, max_cases: 24

.
Finished in 0.00 seconds (0.00s async, 0.00s sync)
1 test, 0 failures
** (RuntimeError) Undefined type (htmlcobertura) is specified for ExCoveralls
    (excoveralls 0.18.5) lib/excoveralls.ex:157: ExCoveralls.analyze/3
    (mix 1.18.2) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.2) lib/mix/cli.ex:107: Mix.CLI.run_task/2
    /Users/pablocostass/code/other/elixir/bin/mix:2: (file)
    (elixir 1.18.2) lib/code.ex:1525: Code.require_file/2
```

With the fix, however, one gets the following output
```
excoveralls_umbrella on  master [!] via 💧 v1.18.2
➜ mix coveralls.multiple --umbrella --type html --type cobertura
==> subapp0
Running ExUnit with seed: 860797, max_cases: 24

..
Finished in 0.00 seconds (0.00s async, 0.00s sync)
2 tests, 0 failures
==> subapp1
Running ExUnit with seed: 860797, max_cases: 24

.
Finished in 0.00 seconds (0.00s async, 0.00s sync)
1 test, 0 failures
----------------
COV    FILE                                        LINES RELEVANT   MISSED
100.0% apps/subapp0/lib/subapp0.ex                     9        2        0
 50.0% apps/subapp1/lib/subapp1.ex                     9        2        1
[TOTAL]  75.0%
----------------
Generating report...
Saved to: cover/
```