### PR TITLE
Stop 100% covered files from overflowing html menu

### DIFF
--- a/lib/templates/html/htmlcov/coverage.html.eex
+++ b/lib/templates/html/htmlcov/coverage.html.eex
@@ -14,7 +14,13 @@
         <%= for file <- @cov.files do %>
           <%= if not @filter_full_covered or file.coverage < 100 do %>
             <li>
-              <span class='cov <%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'><%= file.coverage || 0 %></span>
+              <span class='cov <%= ExCoveralls.Html.View.coverage_class(file.coverage, file.sloc) %>'><%= 
+                case file.coverage do
+                  100.0 -> 100
+                  nil -> 0
+                  cov -> cov
+                end
+              %></span>
               <a href='#<%= file.filename %>'>
                 <% parts = String.split(file.filename, "/") %><% [b | s] = parts |> Enum.reverse |> Enum.reverse_slice(1, Enum.count(parts)) %>
                 <%= if Enum.count(s) do %>


### PR DESCRIPTION
Currently there is a minor graphical issue in the html output when a file has 100% coverage, as can be seen in the screenshot.

<img width="774" height="48" alt="coverage percentage overflow" src="https://github.com/user-attachments/assets/8650332a-4e14-4ab1-88c0-f3340837dfbf" />


This change truncates the coverage percentage from 100.0 to 100 to make it fit within the three-character wide coverage indicator in the overview menu.